### PR TITLE
Update GitHub Copilot to Copilot CLI

### DIFF
--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,16 +1,16 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.429.0",
+  "version": "0.0.407",
   "description": "GitHub's AI pair programmer",
-  "repository": "https://github.com/github/copilot-language-server-release",
+  "repository": "https://github.com/github/copilot-cli",
   "authors": [
     "Microsoft"
   ],
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.429.0",
+      "package": "@github/copilot@0.0.407",
       "args": [
         "--acp"
       ]


### PR DESCRIPTION
Updates GitHub Copilot ACP registry entry to use `@github/copilot`