### PR TITLE
Add xsf-acpkit

### DIFF
--- a/kimi/agent.json
+++ b/kimi/agent.json
@@ -1,43 +1,33 @@
 {
-  "id": "kimi",
-  "name": "Kimi CLI",
-  "version": "1.9.0",
-  "description": "Moonshot AI's coding assistant",
-  "repository": "https://github.com/MoonshotAI/kimi-cli",
-  "authors": [
-    "Moonshot AI"
-  ],
-  "license": "MIT",
-  "distribution": {
-    "binary": {
-      "darwin-aarch64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9/kimi-1.9-aarch64-apple-darwin.tar.gz",
-        "cmd": "./kimi",
-        "args": [
-          "acp"
-        ]
-      },
-      "linux-aarch64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9/kimi-1.9-aarch64-unknown-linux-gnu.tar.gz",
-        "cmd": "./kimi",
-        "args": [
-          "acp"
-        ]
-      },
-      "linux-x86_64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9/kimi-1.9-x86_64-unknown-linux-gnu.tar.gz",
-        "cmd": "./kimi",
-        "args": [
-          "acp"
-        ]
-      },
-      "windows-x86_64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9/kimi-1.9-x86_64-pc-windows-msvc.zip",
-        "cmd": "./kimi.exe",
-        "args": [
-          "acp"
-        ]
-      }
-    }
-  }
+	"id": "kimi",
+	"name": "Kimi CLI",
+	"version": "1.9.0",
+	"description": "Moonshot AI's coding assistant",
+	"repository": "https://github.com/MoonshotAI/kimi-cli",
+	"authors": ["Moonshot AI"],
+	"license": "MIT",
+	"distribution": {
+		"binary": {
+			"darwin-aarch64": {
+				"archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-aarch64-apple-darwin.tar.gz",
+				"cmd": "./kimi",
+				"args": ["acp"]
+			},
+			"linux-aarch64": {
+				"archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-aarch64-unknown-linux-gnu.tar.gz",
+				"cmd": "./kimi",
+				"args": ["acp"]
+			},
+			"linux-x86_64": {
+				"archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-x86_64-unknown-linux-gnu.tar.gz",
+				"cmd": "./kimi",
+				"args": ["acp"]
+			},
+			"windows-x86_64": {
+				"archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-x86_64-pc-windows-msvc.zip",
+				"cmd": "./kimi.exe",
+				"args": ["acp"]
+			}
+		}
+	}
 }

--- a/xsf-acpkit/agent.json
+++ b/xsf-acpkit/agent.json
@@ -1,0 +1,28 @@
+{
+  "id": "xsf-acpkit",
+  "name": "xsf-acpkit",
+  "version": "0.1.0",
+  "description": "ACP agent server that integrates ACP Kit workflows (threads/logs) with Zed (auth via Codex CLI OAuth).",
+  "repository": "https://github.com/haegyung/xsfire",
+  "authors": [
+    "haegyung"
+  ],
+  "license": "proprietary",
+  "icon": "icon.svg",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/haegyung/xsfire/releases/download/xsf-acpkit-v0.1.0/xsf-acpkit-0.1.0-aarch64-apple-darwin.tar.gz",
+        "cmd": "./xsf-acpkit"
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/haegyung/xsfire/releases/download/xsf-acpkit-v0.1.0/xsf-acpkit-0.1.0-x86_64-unknown-linux-gnu.tar.gz",
+        "cmd": "./xsf-acpkit"
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/haegyung/xsfire/releases/download/xsf-acpkit-v0.1.0/xsf-acpkit-0.1.0-x86_64-pc-windows-msvc.zip",
+        "cmd": "xsf-acpkit.exe"
+      }
+    }
+  }
+}

--- a/xsf-acpkit/icon.svg
+++ b/xsf-acpkit/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M2 2h5v5H2V2zm7 0h5v5H9V2zM2 9h5v5H2V9zm7 0h5v1H9V9zm0 2h5v1H9v-1zm0 2h5v1H9v-1z"/>
+</svg>


### PR DESCRIPTION
Adds xsf-acpkit agent pointing to https://github.com/haegyung/xsfire/releases/tag/xsf-acpkit-v0.1.0.

Also fixes kimi agent archive URLs to match upstream release tag/asset naming (1.9.0).