### PR TITLE
Allow binary agents with partial OS coverage

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -425,13 +425,13 @@ def validate_agent(
                             f"Unknown platforms: {', '.join(sorted(unknown_platforms))}"
                         )
 
-                    # Check that all OS families have at least one platform
+                    # Warn if not all OS families have at least one platform
                     provided_os_families = {p.split("-")[0] for p in binary.keys() if p in VALID_PLATFORMS}
                     missing_os_families = REQUIRED_OS_FAMILIES - provided_os_families
                     if missing_os_families:
-                        errors.append(
-                            f"Binary distribution must include builds for all operating systems. "
-                            f"Missing: {', '.join(sorted(missing_os_families))}"
+                        print(
+                            f"Warning: {agent_dir} binary distribution is missing builds for: "
+                            f"{', '.join(sorted(missing_os_families))}"
                         )
 
                     for platform, target in binary.items():

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@
 
 ### Binary Distribution
 
-For standalone executables. **Binary distributions must support all operating systems** (macOS, Linux, and Windows):
+For standalone executables. At least one platform is required; providing builds for all operating systems (macOS, Linux, and Windows) is recommended but not mandatory:
 
 ```json
 {
@@ -94,7 +94,7 @@ For standalone executables. **Binary distributions must support all operating sy
 
 Supported platforms: `darwin-aarch64`, `darwin-x86_64`, `linux-aarch64`, `linux-x86_64`, `windows-aarch64`, `windows-x86_64`
 
-> **Note**: At minimum, you must provide builds for **darwin** (macOS), **linux**, and **windows**. Providing only one OS (e.g., macOS-only) will fail validation.
+> **Note**: Providing builds for all operating systems is recommended. Missing OS families will produce a warning during validation but will not block the build.
 
 ### npm Package (npx)
 
@@ -190,9 +190,9 @@ Entries are validated against the [JSON Schema](agent.schema.json).
 - `linux-aarch64`, `linux-x86_64`
 - `windows-aarch64`, `windows-x86_64`
 
-**Cross-platform requirement** (for binary):
-- Binary distributions must include builds for **all operating systems**: darwin (macOS), linux, and windows
-- At least one architecture per OS is required (e.g., `darwin-aarch64`, `linux-x86_64`, `windows-x86_64`)
+**Cross-platform coverage** (for binary):
+- Providing builds for all operating systems (darwin, linux, windows) is recommended
+- Missing OS families will produce a warning but will not fail validation
 
 **Version matching:**
 - Distribution versions must match the entry's `version` field


### PR DESCRIPTION
## Summary
- Changes the binary distribution OS family check from a build-blocking error to a warning
- Agents like Kiro that only ship macOS + Linux binaries (no Windows) can now be merged
- Updates CONTRIBUTING.md to reflect the relaxed requirement

## Test plan
- [ ] CI "Build & Validate" passes with existing agents
- [ ] Verify warning is printed for agents missing OS families (e.g., Kiro PR #33)