### PR TITLE
Validate and document supported archive formats for binary distribution

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -40,6 +40,7 @@ VALID_PLATFORMS = {
     "windows-x86_64",
 }
 REQUIRED_OS_FAMILIES = {"darwin", "linux", "windows"}
+REJECTED_ARCHIVE_EXTENSIONS = (".dmg", ".pkg", ".deb", ".rpm", ".msi", ".appimage")
 
 # Can be overridden via environment variable
 DEFAULT_BASE_URL = "https://cdn.agentclientprotocol.com/registry/v1/latest"
@@ -440,6 +441,15 @@ def validate_agent(
                                 errors.append(
                                     f"Platform {platform} missing 'archive' field"
                                 )
+                            else:
+                                archive_url = target["archive"].lower()
+                                for ext in REJECTED_ARCHIVE_EXTENSIONS:
+                                    if archive_url.endswith(ext):
+                                        errors.append(
+                                            f"Platform {platform} archive uses unsupported format '{ext}'. "
+                                            f"Supported formats: .zip, .tar.gz, .tgz, .tar.bz2, .tbz2, or raw binaries"
+                                        )
+                                        break
                             if "cmd" not in target:
                                 errors.append(
                                     f"Platform {platform} missing 'cmd' field"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Each directory contains either `agent.json` (for agents) or `extension.json` (fo
 - `version`: semantic versioning (e.g., `1.0.0`)
 - `distribution`: at least one of `binary`, `npx`, `uvx`
 - `binary` distribution: builds for all operating systems (darwin, linux, windows) are recommended; missing OS families produce a warning
+- `binary` archives must use supported formats (`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries); installer formats (`.dmg`, `.pkg`, `.deb`, `.rpm`, `.msi`, `.appimage`) are rejected
 - `icon.svg`: must be SVG format, 16x16, monochrome using `currentColor` (enables theming)
 - **URL validation**: All distribution URLs must be accessible (binary archives, npm/PyPI packages)
 
@@ -88,7 +89,7 @@ Run build to validate: `uv run --with jsonschema .github/workflows/build_registr
 
 ## Distribution Types
 
-- `binary`: Platform-specific archives (`darwin-aarch64`, `linux-x86_64`, etc.). Supporting all operating systems (darwin, linux, windows) is recommended.
+- `binary`: Platform-specific archives (`darwin-aarch64`, `linux-x86_64`, etc.). Supported archive formats: `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries. Supporting all operating systems (darwin, linux, windows) is recommended.
 - `npx`: npm packages (cross-platform by default)
 - `uvx`: PyPI packages (cross-platform by default)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@
 
 ### Binary Distribution
 
-For standalone executables. At least one platform is required; providing builds for all operating systems (macOS, Linux, and Windows) is recommended but not mandatory:
+For standalone executables. At least one platform is required; providing builds for all operating systems (macOS, Linux, and Windows) is recommended but not mandatory.
+
+> **Supported archive formats:** `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries. Installer formats (`.dmg`, `.pkg`, `.deb`, `.rpm`, `.msi`, `.appimage`) are not supported.
 
 ```json
 {
@@ -189,6 +191,10 @@ Entries are validated against the [JSON Schema](agent.schema.json).
 - `darwin-aarch64`, `darwin-x86_64`
 - `linux-aarch64`, `linux-x86_64`
 - `windows-aarch64`, `windows-x86_64`
+
+**Archive formats** (for binary):
+- Supported: `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries
+- Rejected: `.dmg`, `.pkg`, `.deb`, `.rpm`, `.msi`, `.appimage` (installer formats are not supported)
 
 **Cross-platform coverage** (for binary):
 - Providing builds for all operating systems (darwin, linux, windows) is recommended

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -51,6 +51,8 @@ Each entry (agent or extension) has the same structure:
 | `npx`    | npm packages                  | `npx <package> [args]` |
 | `uvx`    | PyPI packages via uv          | `uvx <package> [args]` |
 
+**Supported archive formats for binary distribution:** `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries. Installer formats (`.dmg`, `.pkg`, `.deb`, `.rpm`, `.msi`, `.appimage`) are not supported.
+
 ## Icons
 
 Icons should be SVG format with a **preferred size of 16x16**.

--- a/agent.schema.json
+++ b/agent.schema.json
@@ -88,7 +88,7 @@
         "archive": {
           "type": "string",
           "format": "uri",
-          "description": "URL to download archive"
+          "description": "URL to download archive (.zip, .tar.gz, .tgz, .tar.bz2, .tbz2, or raw binary). Installer formats (.dmg, .pkg, .deb, .rpm) are not supported."
         },
         "cmd": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Add validation in `build_registry.py` to reject unsupported installer formats (`.dmg`, `.pkg`, `.deb`, `.rpm`, `.msi`, `.appimage`) for binary archive URLs
- Document supported archive formats (`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries) across `CONTRIBUTING.md`, `AGENTS.md`, `FORMAT.md`, and `agent.schema.json`

## Context

The client side (IntelliJ `AcpBinaryManager.kt`) supports extracting `.zip`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, and raw binaries — but not installer formats like `.dmg`. The registry previously had no validation on archive format, so any URL was accepted.

## Test plan

- [x] `SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py` passes — all 12 existing agents validate successfully
- [x] CI build passes on PR