### PR TITLE
Update README: remove agents table, link to registry website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ACP Registry
 
-> ⚠️ **Work in Progress**: This registry is under active development. Format and contents may change.
+https://agentclientprotocol.com/registry
 
-A registry of agents implementing the [Agent Client Protocol, ACP](https://github.com/agentclientprotocol/agent-client-protocol).
+Registry of agents implementing the [Agent Client Protocol, ACP](https://github.com/agentclientprotocol/agent-client-protocol).
 
 > **Authentication Required**: This registry maintains a curated list of **agents that support user authentication**.
 >
@@ -10,19 +10,6 @@ A registry of agents implementing the [Agent Client Protocol, ACP](https://githu
 > All agents are verified via CI to ensure they return valid `authMethods` in the ACP handshake.
 > See [AUTHENTICATION.md](AUTHENTICATION.md) for implementation details and the [ACP auth methods proposal](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/rfds/auth-methods.mdx) for the specification.
 
-## Included Agents
-
-| Agent                                                                       | Description                                                                       |
-| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [Auggie CLI](https://github.com/augmentcode/auggie-zed-extension)           | Augment Code's powerful software agent, backed by industry-leading context engine |
-| [Claude Code](https://github.com/zed-industries/claude-code-acp)            | ACP adapter for Claude Code                                                       |
-| [Codex CLI](https://github.com/zed-industries/codex-acp)                    | ACP adapter for OpenAI's coding assistant                                         |
-| Factory Droid                                                               | Factory Droid - AI coding agent powered by Factory AI                             |
-| [Gemini CLI](https://github.com/google-gemini/gemini-cli)                   | Google's official CLI for Gemini                                                  |
-| [GitHub Copilot](https://github.com/github/copilot-language-server-release) | GitHub's AI pair programmer                                                       |
-| [Mistral Vibe](https://github.com/mistralai/mistral-vibe)                   | Mistral's open-source coding assistant                                            |
-| [OpenCode](https://github.com/anomalyco/opencode)                           | The open source coding agent                                                      |
-| [Qwen Code](https://github.com/QwenLM/qwen-code)                            | Alibaba's Qwen coding assistant                                                   |
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Removed the hardcoded agents table from the README since the list is now available at https://agentclientprotocol.com/registry
- Added link to the registry website
- Removed the "work in progress" notice