### PR TITLE
Fix quarantine messages breaking --json output in CI

### DIFF
--- a/.github/workflows/update_versions.py
+++ b/.github/workflows/update_versions.py
@@ -206,14 +206,14 @@ def find_all_agents(registry_dir: Path) -> list[tuple[Path, dict]]:
 
                 agent_id = agent_data.get("id", entry_dir.name)
                 if agent_id in quarantine:
-                    print(f"  ⊘ Quarantined {agent_id}: {quarantine[agent_id]}")
+                    print(f"  ⊘ Quarantined {agent_id}: {quarantine[agent_id]}", file=sys.stderr)
                     continue
 
                 agents.append((agent_json, agent_data))
 
     if quarantine:
-        print(f"  ({len(quarantine)} agent(s) quarantined)")
-        print()
+        print(f"  ({len(quarantine)} agent(s) quarantined)", file=sys.stderr)
+        print(file=sys.stderr)
 
     return agents
 


### PR DESCRIPTION
## Summary
- Moves quarantine log messages in `update_versions.py` from stdout to stderr
- Fixes the CI "Generate commit message" step which pipes `--json` output through `json.load()` and fails because quarantine messages pollute the JSON stream

## Context
The CI workflow failed at https://github.com/agentclientprotocol/registry/actions/runs/22024376813/job/63638577605 with `json.decoder.JSONDecodeError` because the quarantine `⊘ Quarantined opencode: ...` line was printed to stdout before the JSON.

## Test plan
- [x] `python3 .github/workflows/update_versions.py --json 2>/dev/null | python3 -c "import sys,json; json.load(sys.stdin)"` — valid JSON