### PR TITLE
Update opencode to 1.2.5 and remove from quarantine

### DIFF
--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.1.65",
+  "version": "1.2.5",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "authors": [
@@ -12,35 +12,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/quarantine.json
+++ b/quarantine.json
@@ -1,3 +1,2 @@
 {
-  "opencode": "ACP spec violation: writes non-JSON to stdout (database migration logs)"
 }


### PR DESCRIPTION
## Summary
- Update opencode from 1.1.65 to 1.2.5
- Remove from quarantine (previously quarantined for writing non-JSON to stdout)

## Test plan
- [x] `build_registry.py` validation passes
- [ ] CI build and auth verification