### PR TITLE
Fix icon validation currentColor check

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -267,8 +267,20 @@ def validate_icon_monochrome(content: str) -> list[str]:
                 )
                 reported_colors.add(style_stroke.group(1).strip())
 
-    # Check that currentColor is actually used (icons without fill default to black)
-    has_current_color = bool(re.search(r"currentColor", content, re.IGNORECASE))
+    # Check that currentColor is actually used in fill/stroke (icons without fill default to black)
+    has_current_color = any(
+        v.strip().lower() == "currentcolor"
+        for v in fill_matches + stroke_matches
+    )
+    if not has_current_color:
+        # Also check style attributes for fill/stroke with currentColor
+        for style_value in style_matches:
+            style_fill = re.search(r"\bfill\s*:\s*([^;]+)", style_value, re.IGNORECASE)
+            style_stroke = re.search(r"\bstroke\s*:\s*([^;]+)", style_value, re.IGNORECASE)
+            if (style_fill and style_fill.group(1).strip().lower() == "currentcolor") or \
+               (style_stroke and style_stroke.group(1).strip().lower() == "currentcolor"):
+                has_current_color = True
+                break
     if not has_current_color:
         errors.append("Icon must use currentColor for fills/strokes to support theming")
 


### PR DESCRIPTION
## Summary
- The icon monochrome validator used a simple substring search for `currentColor` anywhere in the SVG file
- This allowed icons to pass if `currentColor` appeared only in Inkscape editor metadata (e.g. `bordercolor="currentColor"` in `sodipodi:namedview`) while all visible paths rendered as black
- Now checks that `currentColor` is used in actual `fill=`, `stroke=`, or style `fill:`/`stroke:` values
- Includes corust icon fix (also in #84) so the branch builds cleanly

## Test plan
- [ ] Verify an SVG with only `bordercolor="currentColor"` in metadata is rejected
- [ ] Verify an SVG with `fill="currentColor"` on paths is accepted
- [ ] Run `SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py` passes