### PR TITLE
Install uv in CI for uvx agent verification

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -148,6 +148,9 @@ jobs:
         with:
           node-version: "lts/*"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Apply version updates
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Add `astral-sh/setup-uv@v6` step to the `apply-updates` job in the Update Agent Versions workflow
- Fixes `FileNotFoundError: No such file or directory: 'uvx'` when verifying `minion-code` (the first uvx-based agent in the registry)

## Context
https://github.com/agentclientprotocol/registry/actions/runs/22345165915/job/64657832645