### PR TITLE
Require icon.svg for all agents

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -530,15 +530,16 @@ def process_entry(
                 f"  - {e}" for e in url_errors
             ]
 
-    # Validate and set icon URL if icon exists
+    # Validate icon (required)
     icon_path = entry_dir / "icon.svg"
-    if icon_path.exists():
-        icon_errors = validate_icon(icon_path)
-        if icon_errors:
-            return None, [f"{entry_dir.name}/icon.svg validation failed:"] + [
-                f"  - {e}" for e in icon_errors
-            ]
-        entry["icon"] = f"{base_url}/{entry_id}.svg"
+    if not icon_path.exists():
+        return None, [f"{entry_dir.name}/icon.svg is missing (icon is required)"]
+    icon_errors = validate_icon(icon_path)
+    if icon_errors:
+        return None, [f"{entry_dir.name}/icon.svg validation failed:"] + [
+            f"  - {e}" for e in icon_errors
+        ]
+    entry["icon"] = f"{base_url}/{entry_id}.svg"
 
     return entry, []
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This is a registry of ACP (Agent Client Protocol) agents. The structure is:
 ```
 <id>/
 ├── agent.json      # Agent metadata and distribution info
-└── icon.svg        # Icon: 16x16 SVG, monochrome with currentColor (optional)
+└── icon.svg        # Icon: 16x16 SVG, monochrome with currentColor (required)
 ```
 
 **Build process** (`.github/workflows/build_registry.py`):


### PR DESCRIPTION
## Summary
- Fail the build if an agent is missing `icon.svg` (previously optional, now required)
- Update AGENTS.md to reflect the change

## Test plan
- [x] Build passes with all current agents (all have icons)
- [x] Build fails with clear error when an icon is removed