### PR TITLE
Add retry logic to URL validation and update stakpak to 0.3.64

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -53,20 +53,30 @@ SKIP_URL_VALIDATION = os.environ.get("SKIP_URL_VALIDATION", "").lower() in (
 )
 
 
-def url_exists(url: str, method: str = "HEAD") -> bool:
-    """Check if a URL exists using HEAD or GET request."""
-    try:
-        req = urllib.request.Request(url, method=method)
-        req.add_header("User-Agent", "ACP-Registry-Validator/1.0")
-        with urllib.request.urlopen(req, timeout=15) as response:
-            return response.status in (200, 301, 302)
-    except urllib.error.HTTPError as e:
-        # Some servers don't support HEAD, try GET
-        if method == "HEAD" and e.code in (403, 405):
-            return url_exists(url, method="GET")
-        return False
-    except (urllib.error.URLError, TimeoutError, OSError):
-        return False
+def url_exists(url: str, method: str = "HEAD", retries: int = 3) -> bool:
+    """Check if a URL exists using HEAD or GET request with retries."""
+    import time
+
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, method=method)
+            req.add_header("User-Agent", "ACP-Registry-Validator/1.0")
+            with urllib.request.urlopen(req, timeout=15) as response:
+                return response.status in (200, 301, 302)
+        except urllib.error.HTTPError as e:
+            # Some servers don't support HEAD, try GET
+            if method == "HEAD" and e.code in (403, 405):
+                return url_exists(url, method="GET", retries=retries - attempt)
+            if attempt < retries - 1 and e.code in (429, 500, 502, 503, 504):
+                time.sleep(2**attempt)
+                continue
+            return False
+        except (urllib.error.URLError, TimeoutError, OSError):
+            if attempt < retries - 1:
+                time.sleep(2**attempt)
+                continue
+            return False
+    return False
 
 
 def extract_version_from_url(url: str) -> str | None:

--- a/stakpak/agent.json
+++ b/stakpak/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "stakpak",
   "name": "Stakpak",
-  "version": "0.3.62",
+  "version": "0.3.64",
   "description": "Open-source DevOps agent in Rust with enterprise-grade security",
   "repository": "https://github.com/stakpak/agent",
   "authors": [
@@ -12,35 +12,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-darwin-aarch64.tar.gz",
+        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-darwin-aarch64.tar.gz",
         "cmd": "./stakpak",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-darwin-x86_64.tar.gz",
+        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-darwin-x86_64.tar.gz",
         "cmd": "./stakpak",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-linux-aarch64.tar.gz",
+        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-linux-aarch64.tar.gz",
         "cmd": "./stakpak",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-linux-x86_64.tar.gz",
+        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-linux-x86_64.tar.gz",
         "cmd": "./stakpak",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-windows-x86_64.zip",
+        "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-windows-x86_64.zip",
         "cmd": "./stakpak.exe",
         "args": [
           "acp"


### PR DESCRIPTION
## Summary
- Add exponential backoff retries (3 attempts) to `url_exists()` in `build_registry.py` to handle transient CDN/network failures during URL validation
- Update stakpak from 0.3.62 to 0.3.64 (the CI couldn't commit this update due to the validation failure)

Fixes https://github.com/agentclientprotocol/registry/actions/runs/22484300152/job/65129988920

## Test plan
- [x] `uv run --with jsonschema .github/workflows/build_registry.py` passes locally with all 19 agents