### PR TITLE
Quarantine junie-acp: timeout waiting for initialize response

### DIFF
--- a/quarantine.json
+++ b/quarantine.json
@@ -1,2 +1,3 @@
 {
+  "junie-acp": "Timeout waiting for initialize response"
 }


### PR DESCRIPTION
## Summary
- Quarantine junie-acp until it responds to the ACP `initialize` message
- The agent times out even with 120s timeout (increased in #106), indicating it doesn't respond to the initialize handshake at all

## Context
- Failed run (60s): https://github.com/agentclientprotocol/registry/actions/runs/22490351290/job/65150641794
- Failed run (120s): https://github.com/agentclientprotocol/registry/actions/runs/22492423594/job/65157999851

## Test plan
- [ ] CI passes with junie-acp quarantined