### PR TITLE
Remove claude binary distribution for now

### DIFF
--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -7,32 +7,6 @@
   "authors": ["Anthropic"],
   "license": "proprietary",
   "distribution": {
-    "binary": {
-      "darwin-aarch64": {
-        "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.2/claude-agent-acp-darwin-arm64.zip",
-        "cmd": "./claude-agent-acp"
-      },
-      "darwin-x86_64": {
-        "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.2/claude-agent-acp-darwin-x64.zip",
-        "cmd": "./claude-agent-acp"
-      },
-      "linux-aarch64": {
-        "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.2/claude-agent-acp-linux-arm64.tar.gz",
-        "cmd": "./claude-agent-acp"
-      },
-      "linux-x86_64": {
-        "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.2/claude-agent-acp-linux-x64.tar.gz",
-        "cmd": "./claude-agent-acp"
-      },
-      "windows-aarch64": {
-        "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.2/claude-agent-acp-windows-arm64.zip",
-        "cmd": "./claude-agent-acp.exe"
-      },
-      "windows-x86_64": {
-        "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.2/claude-agent-acp-windows-x64.zip",
-        "cmd": "./claude-agent-acp.exe"
-      }
-    },
     "npx": {
       "package": "@zed-industries/claude-agent-acp@0.19.2"
     }


### PR DESCRIPTION
There is an issue with how the claude SDK handles some built-in executables that only seems to work when bundling Claude Code itself but not the SDK.
