### PR TITLE
Clarify icon field description in agent schema

### DIFF
--- a/agent.schema.json
+++ b/agent.schema.json
@@ -44,7 +44,7 @@
     },
     "icon": {
       "type": "string",
-      "description": "Path to icon file (relative or absolute URL)"
+      "description": "Icon URL (set automatically by the build from the required icon.svg file)"
     },
     "distribution": {
       "type": "object",


### PR DESCRIPTION
## Summary
- Update `agent.schema.json` icon field description to clarify it's set automatically by the build from the required `icon.svg` file (not user-provided)

## Test plan
- [x] Build validates all 21 agents