### PR TITLE
Generate release notes from commit history

### DIFF
--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -181,6 +181,7 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.notes }}
         run: |
           VERSION="v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
 
@@ -191,5 +192,3 @@ jobs:
             dist/agent.schema.json \
             dist/registry.schema.json \
             dist/*.svg
-        env:
-          RELEASE_NOTES: ${{ steps.notes.outputs.notes }}


### PR DESCRIPTION
## Summary

- Replace hardcoded "Auto-generated registry build" release notes with commit messages since the previous release tag
- Add `fetch-depth: 0` to the release job checkout so git history is available
- Uses `gh release list` to find the previous tag, then `git log` to collect commit subjects

For auto-update commits this produces notes like:
```
- Update gemini to 0.31.0
- Update stakpak to 0.3.65
```