### PR TITLE
Document automatic version updates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json
 
 See [FORMAT.md](FORMAT.md) for the registry schema, distribution types, and platform targets.
 
+## Automatic Version Updates
+
+Agent versions are automatically updated via a cron job that runs hourly. It checks for new releases across all supported distribution types (npm, PyPI, GitHub releases) and commits updates directly to `main`.
+
 ## Adding an Agent
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions.


### PR DESCRIPTION
## Summary
- Add "Automatic Version Updates" section to README documenting the hourly cron job that keeps agent versions up to date across npm, PyPI, and GitHub releases

## Test plan
- [x] Verified README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)