### PR TITLE
Add repository URL for cursor agent

### DIFF
--- a/cursor/agent.json
+++ b/cursor/agent.json
@@ -3,6 +3,7 @@
   "name": "Cursor",
   "version": "0.1.0",
   "description": "Cursor's coding agent",
+  "repository": "https://cursor.com/docs/cli/acp",
   "authors": [
     "Cursor"
   ],


### PR DESCRIPTION
## Summary
- add `repository` metadata to `cursor/agent.json`
- point to Cursor ACP docs at `https://cursor.com/docs/cli/acp`
- keep all existing distribution and command configuration unchanged

## Test plan
- [x] Run `uv run --with jsonschema .github/workflows/build_registry.py --dry-run`
- [x] Confirm only `cursor/agent.json` changed

Made with [Cursor](https://cursor.com)