### PR TITLE
Skip non-GitHub repository URLs in version checker

### DIFF
--- a/.github/workflows/tests/test_update_versions.py
+++ b/.github/workflows/tests/test_update_versions.py
@@ -1,11 +1,12 @@
 """Tests for update_versions.py."""
 
 import urllib.error
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from update_versions import make_request
+from update_versions import check_agent_version, make_request
 
 
 class TestMakeRequestServerErrors:
@@ -78,3 +79,67 @@ class TestMakeRequestServerErrors:
         )
         with pytest.raises(urllib.error.HTTPError, match="429"):
             make_request("https://example.com/api")
+
+
+class TestCheckAgentVersionNonGitHubRepo:
+    """Test that non-GitHub repository URLs are skipped for binary distributions."""
+
+    def test_non_github_repo_binary_only_is_skipped(self):
+        """Binary-only agent with non-GitHub repository should be silently skipped."""
+        agent_data = {
+            "id": "cursor",
+            "version": "0.1.0",
+            "repository": "https://cursor.com/docs/cli/acp",
+            "distribution": {
+                "binary": {
+                    "darwin-aarch64": {
+                        "archive": "https://example.com/agent.tar.gz",
+                        "cmd": "./agent",
+                    }
+                }
+            },
+        }
+        update, error = check_agent_version(Path("cursor/agent.json"), agent_data)
+        assert update is None
+        assert error is None
+
+    def test_no_repo_binary_only_is_skipped(self):
+        """Binary-only agent with no repository should be silently skipped."""
+        agent_data = {
+            "id": "some-agent",
+            "version": "1.0.0",
+            "distribution": {
+                "binary": {
+                    "darwin-aarch64": {
+                        "archive": "https://example.com/agent.tar.gz",
+                        "cmd": "./agent",
+                    }
+                }
+            },
+        }
+        update, error = check_agent_version(Path("some-agent/agent.json"), agent_data)
+        assert update is None
+        assert error is None
+
+    @patch("update_versions.get_github_latest_release")
+    def test_github_repo_binary_still_checked(self, mock_gh_release):
+        """Binary agent with GitHub repository should still be checked."""
+        mock_gh_release.return_value = ("2.0.0", ["asset.tar.gz"])
+        agent_data = {
+            "id": "some-agent",
+            "version": "1.0.0",
+            "repository": "https://github.com/owner/repo",
+            "distribution": {
+                "binary": {
+                    "darwin-aarch64": {
+                        "archive": "https://github.com/owner/repo/releases/download/v1.0.0/agent.tar.gz",
+                        "cmd": "./agent",
+                    }
+                }
+            },
+        }
+        update, error = check_agent_version(Path("some-agent/agent.json"), agent_data)
+        assert error is None
+        assert update is not None
+        assert update.latest_version == "2.0.0"
+        mock_gh_release.assert_called_once_with("https://github.com/owner/repo")

--- a/.github/workflows/update_versions.py
+++ b/.github/workflows/update_versions.py
@@ -228,7 +228,7 @@ def check_agent_version(
             return None, None  # Skip pre-release versions
         source_versions["uvx"] = (latest, f"https://pypi.org/pypi/{package_name}/json")
 
-    if "binary" in distribution and repository:
+    if "binary" in distribution and repository and "github.com" in repository:
         latest, _assets = get_github_latest_release(repository)
         if not latest:
             return None, UpdateError(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Agent versions are automatically updated via `.github/workflows/update-versions.
 
 - **Schedule:** Runs hourly (cron: `0 * * * *`)
 - **Scope:** Checks all agents in the root directory
-- **Supported distributions:** `npx` (npm), `uvx` (PyPI), `binary` (GitHub releases)
+- **Supported distributions:** `npx` (npm), `uvx` (PyPI), `binary` (GitHub releases only — non-GitHub `repository` URLs are skipped)
 
 ```bash
 # Dry run - check for available updates
@@ -94,7 +94,7 @@ The workflow can also be triggered manually via GitHub Actions with options to a
 To update agents manually:
 
 1. **For npm packages** (`npx` distribution): Check latest version at `https://registry.npmjs.org/<package>/latest`
-2. **For GitHub binaries** (`binary` distribution): Check latest release at `https://api.github.com/repos/<owner>/<repo>/releases/latest`
+2. **For GitHub binaries** (`binary` distribution): Check latest release at `https://api.github.com/repos/<owner>/<repo>/releases/latest`. Note: automated version checking only works for agents with a GitHub `repository` URL. Proprietary agents with non-GitHub or missing `repository` URLs must be updated manually.
 
 Update `agent.json`:
 


### PR DESCRIPTION
## Summary

- Skip binary version checking when the `repository` URL is not a GitHub URL (e.g. `https://cursor.com/docs/cli/acp`)
- Previously this caused errors like `Could not fetch GitHub release for https://cursor.com/docs/cli/acp` which failed the entire update workflow
- GitHub release lookups now only run when `"github.com"` is in the repository URL
- Updated AGENTS.md to document this behavior

Refs: #141

## Test plan

- [x] Added test: non-GitHub repository URL with binary distribution is silently skipped
- [x] Added test: missing repository with binary distribution is silently skipped  
- [x] Added test: GitHub repository URL with binary distribution is still checked
- [x] All 53 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)