### PR TITLE
ci: improve workflow validation parity

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -12,11 +12,11 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from registry_utils import (
-    SKIP_DIRS,
     extract_npm_package_name,
     extract_npm_package_version,
     extract_pypi_package_name,
     normalize_version,
+    should_skip_dir,
 )
 
 try:
@@ -535,7 +535,7 @@ def build_registry(dry_run: bool = False):
         print("  Install with: pip install jsonschema")
 
     for entry_dir in sorted(registry_dir.iterdir()):
-        if not entry_dir.is_dir() or entry_dir.name in SKIP_DIRS:
+        if not entry_dir.is_dir() or should_skip_dir(entry_dir.name):
             continue
 
         agent_json_path = entry_dir / "agent.json"

--- a/.github/workflows/daily-protocol-matrix.yml
+++ b/.github/workflows/daily-protocol-matrix.yml
@@ -70,7 +70,7 @@ jobs:
           XDG_CONFIG_HOME: ${{ runner.temp }}/xdg-config
         run: |
           AGENTS_INPUT=""
-          SKIP_INPUT="crow-cli"
+          SKIP_INPUT=""
           TABLE_MODE="capabilities"
           CHANGED_ONLY="false"
 
@@ -86,7 +86,7 @@ jobs:
           ARGS=(
             --sandbox-dir .matrix-sandbox
             --output-dir .protocol-matrix
-            --init-timeout 45
+            --init-timeout 120
             --rpc-timeout 5
             --table-mode "$TABLE_MODE"
           )

--- a/.github/workflows/docker/registry-entrypoint.sh
+++ b/.github/workflows/docker/registry-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+find_nss_wrapper() {
+  for candidate in /usr/lib/*/libnss_wrapper.so /lib/*/libnss_wrapper.so; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+setup_user() {
+  uid="$(id -u)"
+  gid="$(id -g)"
+  home_dir="${HOME:-/tmp}"
+  passwd_file="$home_dir/.nss-passwd"
+  group_file="$home_dir/.nss-group"
+
+  mkdir -p "$home_dir"
+  export USER="${USER:-codex}"
+  export LOGNAME="${LOGNAME:-$USER}"
+
+  if grep -Eq "^[^:]*:[^:]*:${uid}:" /etc/passwd; then
+    return 0
+  fi
+
+  cp /etc/passwd "$passwd_file"
+  cp /etc/group "$group_file"
+
+  if ! grep -Eq "^[^:]*:[^:]*:${gid}:" "$group_file"; then
+    printf '%s:x:%s:\n' "$USER" "$gid" >> "$group_file"
+  fi
+
+  printf '%s:x:%s:%s:Codex Container User:%s:/bin/sh\n' "$USER" "$uid" "$gid" "$home_dir" >> "$passwd_file"
+
+  nss_wrapper_lib="$(find_nss_wrapper || true)"
+  if [ -n "$nss_wrapper_lib" ]; then
+    export NSS_WRAPPER_PASSWD="$passwd_file"
+    export NSS_WRAPPER_GROUP="$group_file"
+    if [ -n "${LD_PRELOAD:-}" ]; then
+      export LD_PRELOAD="$nss_wrapper_lib:$LD_PRELOAD"
+    else
+      export LD_PRELOAD="$nss_wrapper_lib"
+    fi
+  fi
+}
+
+setup_user
+exec "$@"

--- a/.github/workflows/docker/registry-tools.Dockerfile
+++ b/.github/workflows/docker/registry-tools.Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim AS node-runtime
+
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -12,15 +14,26 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         git \
+        libgomp1 \
+        libnss-wrapper \
         python3 \
         python3-pip \
         python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m venv /opt/uv \
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY docker/registry-entrypoint.sh /usr/local/bin/registry-entrypoint.sh
+
+RUN rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+    && ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack \
+    && python3 -m venv /opt/uv \
     && /opt/uv/bin/pip install --no-cache-dir uv \
     && ln -s /opt/uv/bin/uv /usr/local/bin/uv \
     && printf '#!/bin/sh\nexec /usr/local/bin/uv tool run "$@"\n' > /usr/local/bin/uvx \
-    && chmod +x /usr/local/bin/uvx
+    && chmod +x /usr/local/bin/uvx /usr/local/bin/registry-entrypoint.sh
 
 WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/registry-entrypoint.sh"]

--- a/.github/workflows/protocol_matrix.py
+++ b/.github/workflows/protocol_matrix.py
@@ -34,8 +34,11 @@ from typing import Any
 
 from verify_agents import build_agent_command, load_registry, prepare_binary
 
-DEFAULT_INIT_TIMEOUT = 45.0
+DEFAULT_INIT_TIMEOUT = 120.0
 DEFAULT_RPC_TIMEOUT = 5.0
+DEFAULT_EXIT_GRACE = 0.25
+EXIT_GRACE_POLL_INTERVAL = 0.05
+EXIT_GRACE_REAP_SLACK = 0.05
 DEFAULT_SANDBOX_DIR = ".matrix-sandbox"
 DEFAULT_OUTPUT_DIR = ".protocol-matrix"
 DEFAULT_TABLE_MODE = "full"
@@ -330,23 +333,79 @@ def send_jsonrpc_request(
     proc.stdin.flush()
 
 
+def process_exit_outcome(
+    exit_code: int,
+    method: str,
+) -> tuple[ProbeOutcome, dict[str, Any] | None]:
+    """Build a normalized process-exit outcome for a pending request."""
+    return (
+        ProbeOutcome(
+            status="process_error",
+            message=f"process exited with code {exit_code} before responding to {method}",
+        ),
+        None,
+    )
+
+
+def reconcile_timed_out_request(
+    proc: subprocess.Popen,
+    request_id: int,
+    method: str,
+    exit_grace: float,
+) -> tuple[ProbeOutcome, dict[str, Any] | None] | None:
+    """Reconcile a timed-out request with a near-immediate exit or late response."""
+    if exit_grace <= 0:
+        return None
+
+    deadline = time.monotonic() + exit_grace
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+
+        message = read_jsonrpc_line(proc, min(remaining, EXIT_GRACE_POLL_INTERVAL))
+        if message is None:
+            exit_code = proc.poll()
+            if exit_code is not None:
+                return process_exit_outcome(exit_code, method)
+            continue
+
+        if "_decode_error" in message:
+            return (
+                ProbeOutcome(status="decode_error", message=message["_decode_error"]),
+                None,
+            )
+
+        if message.get("id") == request_id and ("result" in message or "error" in message):
+            return classify_rpc_response(message), message
+
+    exit_code = proc.poll()
+    if exit_code is not None:
+        return process_exit_outcome(exit_code, method)
+
+    if EXIT_GRACE_REAP_SLACK > 0:
+        try:
+            exit_code = proc.wait(timeout=EXIT_GRACE_REAP_SLACK)
+        except subprocess.TimeoutExpired:
+            exit_code = None
+        if exit_code is not None:
+            return process_exit_outcome(exit_code, method)
+
+    return None
+
+
 def request_with_timeout(
     proc: subprocess.Popen,
     request_id: int,
     method: str,
     params: dict[str, Any],
     timeout: float,
+    exit_grace: float = DEFAULT_EXIT_GRACE,
 ) -> tuple[ProbeOutcome, dict[str, Any] | None]:
     """Send request and wait for the response with matching id."""
     exit_code = proc.poll()
     if exit_code is not None:
-        return (
-            ProbeOutcome(
-                status="process_error",
-                message=f"process exited with code {exit_code} before {method}",
-            ),
-            None,
-        )
+        return process_exit_outcome(exit_code, method)
 
     try:
         send_jsonrpc_request(proc, request_id, method, params)
@@ -372,15 +431,7 @@ def request_with_timeout(
         if message is None:
             exit_code = proc.poll()
             if exit_code is not None:
-                return (
-                    ProbeOutcome(
-                        status="process_error",
-                        message=(
-                            f"process exited with code {exit_code} before responding to {method}"
-                        ),
-                    ),
-                    None,
-                )
+                return process_exit_outcome(exit_code, method)
             break
 
         if "_decode_error" in message:
@@ -391,6 +442,10 @@ def request_with_timeout(
 
         if message.get("id") == request_id and ("result" in message or "error" in message):
             return classify_rpc_response(message), message
+
+    reconciled = reconcile_timed_out_request(proc, request_id, method, exit_grace)
+    if reconciled is not None:
+        return reconciled
 
     return (
         ProbeOutcome(status="no_response", message=f"timeout after {timeout:.1f}s"),
@@ -737,11 +792,22 @@ def ensure_binary_executable(cmd: list[str], dist_type: str) -> ProbeOutcome | N
         return None
 
     exe_path = Path(cmd[0])
-    if not exe_path.exists() or os.access(exe_path, os.X_OK):
+    if not exe_path.exists():
         return None
 
     try:
-        exe_path.chmod(exe_path.stat().st_mode | 0o755)
+        current_mode = exe_path.stat().st_mode
+    except OSError as exc:
+        return ProbeOutcome(
+            status="process_error",
+            message=short_message(f"Failed to inspect executable {exe_path}: {exc}"),
+        )
+
+    if current_mode & 0o111:
+        return None
+
+    try:
+        exe_path.chmod(current_mode | 0o755)
     except OSError as exc:
         return ProbeOutcome(
             status="process_error",

--- a/.github/workflows/registry_utils.py
+++ b/.github/workflows/registry_utils.py
@@ -18,6 +18,11 @@ SKIP_DIRS = {
 }
 
 
+def should_skip_dir(name: str) -> bool:
+    """Return whether a top-level directory should be skipped during registry scans."""
+    return name in SKIP_DIRS or name.startswith(".")
+
+
 def extract_npm_package_name(package_spec: str) -> str:
     """Extract npm package name from spec like @scope/name@version."""
     if package_spec.startswith("@"):

--- a/.github/workflows/scripts/run-protocol-matrix.sh
+++ b/.github/workflows/scripts/run-protocol-matrix.sh
@@ -3,17 +3,64 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TABLE_MODE="${ACP_PROTOCOL_MATRIX_TABLE_MODE:-capabilities}"
+SKIP_AGENTS="${ACP_PROTOCOL_MATRIX_SKIP_AGENTS:-}"
+KEEP_STATE="${ACP_PROTOCOL_MATRIX_KEEP_STATE:-0}"
+SANDBOX_DIR="${ACP_PROTOCOL_MATRIX_SANDBOX_DIR:-}"
+TEMP_STATE_DIR=""
+TEMP_SANDBOX_DIR=""
+TEMP_SANDBOX_ROOT="$ROOT/.matrix-sandbox/.tmp"
+TEMP_STATE_ROOT="$ROOT/.docker-state/.tmp"
+
+cleanup() {
+  if [[ -n "$TEMP_SANDBOX_DIR" ]]; then
+    rm -rf "$TEMP_SANDBOX_DIR"
+  fi
+  if [[ -n "$TEMP_STATE_DIR" ]]; then
+    rm -rf "$TEMP_STATE_DIR"
+  fi
+}
+
+if [[ -z "$SANDBOX_DIR" ]]; then
+  if [[ "$KEEP_STATE" == "1" ]]; then
+    SANDBOX_DIR=".matrix-sandbox"
+  else
+    mkdir -p "$TEMP_SANDBOX_ROOT"
+    TEMP_SANDBOX_DIR="$(mktemp -d "$TEMP_SANDBOX_ROOT/protocol-matrix-sandbox.XXXXXX")"
+    SANDBOX_DIR="${TEMP_SANDBOX_DIR#"$ROOT"/}"
+  fi
+fi
+
 ARGS=(
   python3
   .github/workflows/protocol_matrix.py
   --sandbox-dir
-  .matrix-sandbox
+  "$SANDBOX_DIR"
   --output-dir
   .protocol-matrix
+  --init-timeout
+  120
+  --rpc-timeout
+  5
+  --table-mode
+  "$TABLE_MODE"
 )
 
-if [[ -n "${ACP_PROTOCOL_MATRIX_SKIP_AGENTS:-}" ]]; then
-  ARGS+=(--skip-agent "$ACP_PROTOCOL_MATRIX_SKIP_AGENTS")
+if [[ -n "$SKIP_AGENTS" ]]; then
+  ARGS+=(--skip-agent "$SKIP_AGENTS")
 fi
 
-exec "$SCRIPT_DIR/run-registry-docker.sh" "${ARGS[@]}" "$@"
+if [[ -z "${ACP_REGISTRY_STATE_DIR:-}" && "$KEEP_STATE" != "1" ]]; then
+  mkdir -p "$TEMP_STATE_ROOT"
+  TEMP_STATE_DIR="$(mktemp -d "$TEMP_STATE_ROOT/protocol-matrix-state.XXXXXX")"
+fi
+
+if [[ -n "$TEMP_SANDBOX_DIR" || -n "$TEMP_STATE_DIR" ]]; then
+  trap cleanup EXIT
+fi
+
+if [[ -n "$TEMP_STATE_DIR" ]]; then
+  export ACP_REGISTRY_STATE_DIR="${TEMP_STATE_DIR#"$ROOT"/}"
+fi
+
+"$SCRIPT_DIR/run-registry-docker.sh" "${ARGS[@]}" "$@"

--- a/.github/workflows/scripts/run-registry-docker.sh
+++ b/.github/workflows/scripts/run-registry-docker.sh
@@ -6,7 +6,8 @@ IMAGE="${ACP_REGISTRY_IMAGE:-acp-registry-tools}"
 WORKFLOWS_DIR="$ROOT/.github/workflows"
 DOCKERFILE="${ACP_REGISTRY_DOCKERFILE:-$WORKFLOWS_DIR/docker/registry-tools.Dockerfile}"
 DOCKER_CONTEXT="${ACP_REGISTRY_DOCKER_CONTEXT:-$WORKFLOWS_DIR}"
-BUILD_IMAGE="${ACP_REGISTRY_BUILD_IMAGE:-1}"
+DOCKER_PLATFORM="${ACP_REGISTRY_DOCKER_PLATFORM:-linux/amd64}"
+BUILD_IMAGE="${ACP_REGISTRY_BUILD_IMAGE:-auto}"
 STATE_DIR_REL="${ACP_REGISTRY_STATE_DIR:-.docker-state}"
 STATE_DIR_HOST="$ROOT/$STATE_DIR_REL"
 STATE_DIR_CONTAINER="/workspace/$STATE_DIR_REL"
@@ -14,24 +15,122 @@ HOME_DIR_CONTAINER="$STATE_DIR_CONTAINER/home"
 UV_CACHE_DIR_CONTAINER="$STATE_DIR_CONTAINER/uv-cache"
 NPM_CACHE_DIR_CONTAINER="$STATE_DIR_CONTAINER/npm-cache"
 XDG_CACHE_DIR_CONTAINER="$STATE_DIR_CONTAINER/xdg-cache"
-XDG_CONFIG_DIR_CONTAINER="$HOME_DIR_CONTAINER/.config"
+XDG_CONFIG_DIR_CONTAINER="$STATE_DIR_CONTAINER/xdg-config"
+BUILD_HASH_LABEL="org.openai.acp-registry.build-hash"
+
+hash_cmd() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$@"
+    return
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@"
+    return
+  fi
+
+  echo "Missing SHA-256 command (expected shasum or sha256sum)" >&2
+  exit 2
+}
+
+compute_build_hash() {
+  local file
+
+  {
+    for file in "$@"; do
+      printf '%s  %s\n' "$(hash_cmd "$file" | awk '{print $1}')" "$file"
+    done
+  } | hash_cmd | awk '{print $1}'
+}
+
+image_platform() {
+  docker image inspect "$IMAGE" --format '{{.Os}}/{{.Architecture}}{{if .Variant}}/{{.Variant}}{{end}}'
+}
+
+image_build_hash() {
+  docker image inspect "$IMAGE" \
+    --format '{{range $key, $value := .Config.Labels}}{{printf "%s=%s\n" $key $value}}{{end}}' \
+    | awk -F= -v key="$BUILD_HASH_LABEL" '$1 == key { print $2; exit }'
+}
+
+image_needs_rebuild() {
+  local current_build_hash=""
+  local current_platform=""
+
+  if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ -n "$DOCKER_PLATFORM" ]]; then
+    current_platform="$(image_platform 2>/dev/null || true)"
+    if [[ "$current_platform" != "$DOCKER_PLATFORM" ]]; then
+      return 0
+    fi
+  fi
+
+  current_build_hash="$(image_build_hash 2>/dev/null || true)"
+  if [[ "$current_build_hash" != "$BUILD_HASH" ]]; then
+    return 0
+  fi
+
+  return 1
+}
 
 if [[ $# -eq 0 ]]; then
   echo "Usage: $0 <command> [args...]" >&2
   exit 1
 fi
 
+DOCKER_PLATFORM_ARGS=()
+if [[ -n "$DOCKER_PLATFORM" ]]; then
+  DOCKER_PLATFORM_ARGS=(--platform "$DOCKER_PLATFORM")
+fi
+
+IMAGE_INPUT_FILES=("$DOCKERFILE")
+if [[ -f "$WORKFLOWS_DIR/docker/registry-entrypoint.sh" ]]; then
+  IMAGE_INPUT_FILES+=("$WORKFLOWS_DIR/docker/registry-entrypoint.sh")
+fi
+BUILD_HASH="$(compute_build_hash "${IMAGE_INPUT_FILES[@]}")"
+
 mkdir -p \
-  "$STATE_DIR_HOST/home/.config" \
+  "$STATE_DIR_HOST/home" \
   "$STATE_DIR_HOST/uv-cache" \
   "$STATE_DIR_HOST/npm-cache" \
-  "$STATE_DIR_HOST/xdg-cache"
+  "$STATE_DIR_HOST/xdg-cache" \
+  "$STATE_DIR_HOST/xdg-config"
 
-if [[ "$BUILD_IMAGE" == "1" ]]; then
-  docker build -f "$DOCKERFILE" -t "$IMAGE" "$DOCKER_CONTEXT"
+case "$BUILD_IMAGE" in
+  1|true|yes)
+    SHOULD_BUILD=1
+    ;;
+  0|false|no)
+    SHOULD_BUILD=0
+    ;;
+  auto)
+    if image_needs_rebuild; then
+      SHOULD_BUILD=1
+    else
+      SHOULD_BUILD=0
+    fi
+    ;;
+  *)
+    echo "Invalid ACP_REGISTRY_BUILD_IMAGE value: $BUILD_IMAGE" >&2
+    echo "Expected one of: auto, 0, 1" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$SHOULD_BUILD" == "1" ]]; then
+  docker build \
+    "${DOCKER_PLATFORM_ARGS[@]}" \
+    --label "$BUILD_HASH_LABEL=$BUILD_HASH" \
+    -f "$DOCKERFILE" \
+    -t "$IMAGE" \
+    "$DOCKER_CONTEXT"
 fi
 
 exec docker run --rm \
+  "${DOCKER_PLATFORM_ARGS[@]}" \
   --user "$(id -u):$(id -g)" \
   -e HOME="$HOME_DIR_CONTAINER" \
   -e UV_CACHE_DIR="$UV_CACHE_DIR_CONTAINER" \

--- a/.github/workflows/scripts/run-workflows-tests.sh
+++ b/.github/workflows/scripts/run-workflows-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/run-registry-docker.sh" \
+  /bin/sh -lc 'cd /workspace/.github/workflows && uv run --no-project --with pytest pytest tests/ -v "$@"' \
+  run-workflows-tests "$@"

--- a/.github/workflows/tests/test_protocol_matrix.py
+++ b/.github/workflows/tests/test_protocol_matrix.py
@@ -258,6 +258,57 @@ def test_request_with_timeout_reports_exited_process():
     assert message is None
 
 
+def test_request_with_timeout_reclassifies_timeout_when_process_exits_during_grace():
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            ("import sys,time; sys.stdin.readline(); time.sleep(0.03); sys.exit(9)"),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    outcome, message = request_with_timeout(proc, 1, "initialize", {}, 0.005, exit_grace=0.5)
+
+    assert outcome.status == "process_error"
+    assert "code 9" in (outcome.message or "")
+    assert message is None
+
+
+def test_request_with_timeout_keeps_no_response_when_process_stays_alive():
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            ("import sys,time; sys.stdin.readline(); time.sleep(1)"),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        outcome, message = request_with_timeout(
+            proc,
+            1,
+            "initialize",
+            {},
+            0.02,
+            exit_grace=0.05,
+        )
+    finally:
+        proc.terminate()
+        proc.wait(timeout=2)
+
+    assert outcome.status == "no_response"
+    assert "timeout after 0.0s" in (outcome.message or "")
+    assert message is None
+
+
 def test_feature_cell_formats_advertised_and_probe():
     cell = feature_cell(True, ProbeOutcome(status="invalid_params"))
     assert cell == "Y/yes"

--- a/.github/workflows/tests/test_registry_utils.py
+++ b/.github/workflows/tests/test_registry_utils.py
@@ -10,6 +10,7 @@ from registry_utils import (
     extract_pypi_package_name,
     load_quarantine,
     normalize_version,
+    should_skip_dir,
 )
 
 
@@ -95,3 +96,14 @@ class TestLoadQuarantine:
             p = Path(d) / "quarantine.json"
             p.write_text("not json")
             assert load_quarantine(Path(d)) == {}
+
+
+class TestShouldSkipDir:
+    def test_skips_hidden_runtime_dirs(self):
+        assert should_skip_dir(".sandbox")
+        assert should_skip_dir(".matrix-sandbox-debug")
+        assert should_skip_dir(".protocol-matrix-goose-check")
+        assert should_skip_dir(".tmp-junie-run")
+
+    def test_keeps_agent_dirs(self):
+        assert not should_skip_dir("codex-acp")

--- a/.github/workflows/tests/test_verify_agents.py
+++ b/.github/workflows/tests/test_verify_agents.py
@@ -1,0 +1,76 @@
+import os
+import stat
+from pathlib import Path
+
+from verify_agents import (
+    build_installed_npx_command,
+    ensure_executable,
+    npm_package_bin_name,
+    resolve_binary_executable,
+    should_retry_npx_auth_with_install,
+)
+
+
+def test_resolve_binary_executable_renames_single_raw_binary(tmp_path: Path):
+    raw_binary = tmp_path / "downloaded-binary"
+    raw_binary.write_text("#!/bin/sh\n")
+
+    resolved = resolve_binary_executable(tmp_path, "./agent")
+
+    assert resolved == tmp_path / "agent"
+    assert resolved.exists()
+    assert not raw_binary.exists()
+
+
+def test_ensure_executable_adds_execute_bits(tmp_path: Path):
+    binary = tmp_path / "tool"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o644)
+
+    ensure_executable(binary)
+
+    assert binary.stat().st_mode & stat.S_IXUSR
+    assert os.access(binary, os.X_OK)
+
+
+def test_npm_package_bin_name_uses_declared_bin(tmp_path: Path):
+    package_dir = tmp_path / "node_modules" / "@jetbrains" / "junie"
+    package_dir.mkdir(parents=True)
+    (package_dir / "package.json").write_text(
+        '{"name":"@jetbrains/junie","bin":{"junie":"bin/index.js"}}'
+    )
+
+    assert npm_package_bin_name("@jetbrains/junie@888.173.0", tmp_path) == "junie"
+
+
+def test_build_installed_npx_command_prefers_home_shim(tmp_path: Path):
+    package_dir = tmp_path / "node_modules" / "@jetbrains" / "junie"
+    package_dir.mkdir(parents=True)
+    (package_dir / "package.json").write_text(
+        '{"name":"@jetbrains/junie","bin":{"junie":"bin/index.js"}}'
+    )
+
+    local_bin = tmp_path / "node_modules" / ".bin"
+    local_bin.mkdir(parents=True)
+    (local_bin / "junie").write_text("#!/bin/sh\n")
+
+    auth_home = tmp_path / "auth-home"
+    home_bin = auth_home / ".local" / "bin"
+    home_bin.mkdir(parents=True)
+    (home_bin / "junie").write_text("#!/bin/sh\n")
+
+    command = build_installed_npx_command(
+        "@jetbrains/junie@888.173.0",
+        ["--acp=true"],
+        tmp_path,
+        auth_home,
+    )
+
+    assert command == [str(home_bin / "junie"), "--acp=true"]
+
+
+def test_should_retry_npx_auth_with_install_on_shim_error():
+    assert should_retry_npx_auth_with_install(
+        "Timeout after 120s waiting for initialize response",
+        "[Junie] Shim not found at /tmp/home/.local/bin/junie\nPlease reinstall: npm install",
+    )

--- a/.github/workflows/update_versions.py
+++ b/.github/workflows/update_versions.py
@@ -27,10 +27,10 @@ from pathlib import Path
 from typing import NamedTuple
 
 from registry_utils import (
-    SKIP_DIRS,
     extract_npm_package_name,
     extract_pypi_package_name,
     load_quarantine,
+    should_skip_dir,
 )
 
 
@@ -161,9 +161,7 @@ def find_all_agents(registry_dir: Path) -> list[tuple[Path, dict]]:
         for entry_dir in sorted(base_path.iterdir()):
             if not entry_dir.is_dir():
                 continue
-            if entry_dir.name in SKIP_DIRS:
-                continue
-            if entry_dir.name.startswith("."):
+            if should_skip_dir(entry_dir.name):
                 continue
 
             agent_json = entry_dir / "agent.json"

--- a/.github/workflows/verify_agents.py
+++ b/.github/workflows/verify_agents.py
@@ -18,7 +18,7 @@ import zipfile
 from pathlib import Path
 from typing import NamedTuple
 
-from registry_utils import SKIP_DIRS, load_quarantine
+from registry_utils import extract_npm_package_name, load_quarantine, should_skip_dir
 
 # Import auth client (only needed when --auth-check is used)
 try:
@@ -42,6 +42,11 @@ DEFAULT_TIMEOUT = 10  # seconds
 STARTUP_GRACE = 2  # seconds to wait before checking if process is alive
 DEFAULT_SANDBOX_DIR = ".sandbox"
 DEFAULT_AUTH_TIMEOUT = 120  # seconds for ACP handshake (includes npx download time)
+SYSTEM_COMMANDS = {"node", "python", "python3", "java", "ruby"}
+NPX_INSTALL_RETRY_PATTERNS = (
+    "shim not found",
+    "please reinstall: npm install",
+)
 
 
 class Result(NamedTuple):
@@ -143,6 +148,141 @@ def run_process(cmd: list[str], cwd: Path, env: dict, timeout: int) -> tuple[int
         return -1, "", f"Execution error: {e}"
 
 
+def normalize_command_path(cmd: str) -> str:
+    """Normalize command paths like ./tool to tool for lookup."""
+    return cmd[2:] if cmd.startswith("./") else cmd
+
+
+def ensure_executable(path: Path) -> None:
+    """Ensure a file has executable permissions on non-Windows platforms."""
+    if platform.system() == "Windows" or not path.exists() or not path.is_file():
+        return
+
+    current_mode = path.stat().st_mode
+    if current_mode & 0o111:
+        return
+
+    path.chmod(current_mode | 0o755)
+
+
+def resolve_binary_executable(extract_dir: Path, cmd: str) -> Path | None:
+    """Resolve the executable path for a prepared binary distribution."""
+    target_cmd = normalize_command_path(cmd)
+
+    if target_cmd in SYSTEM_COMMANDS:
+        system_cmd = shutil.which(target_cmd)
+        return Path(system_cmd) if system_cmd else None
+
+    for path in extract_dir.rglob(target_cmd):
+        return path
+
+    files_in_extract = list(extract_dir.iterdir()) if extract_dir.exists() else []
+    if len(files_in_extract) == 1 and files_in_extract[0].is_file():
+        raw_file = files_in_extract[0]
+        expected_path = extract_dir / target_cmd
+        if raw_file != expected_path and not expected_path.exists():
+            raw_file.rename(expected_path)
+        return expected_path
+
+    return extract_dir / target_cmd
+
+
+def should_retry_npx_auth_with_install(error: str | None, stderr_tail: str | None) -> bool:
+    """Detect npm packages that require a real install before auth probing."""
+    combined = "\n".join(part for part in (error, stderr_tail) if part).lower()
+    return any(pattern in combined for pattern in NPX_INSTALL_RETRY_PATTERNS)
+
+
+def npm_package_bin_name(package_spec: str, sandbox: Path) -> str:
+    """Determine the executable name exposed by an installed npm package."""
+    package_name = extract_npm_package_name(package_spec)
+    default_bin = package_name.rsplit("/", maxsplit=1)[-1]
+    package_json = sandbox / "node_modules" / package_name / "package.json"
+
+    if not package_json.exists():
+        return default_bin
+
+    try:
+        package_data = json.loads(package_json.read_text())
+    except (json.JSONDecodeError, OSError):
+        return default_bin
+
+    bin_field = package_data.get("bin")
+    if isinstance(bin_field, str):
+        return default_bin
+    if isinstance(bin_field, dict):
+        if default_bin in bin_field:
+            return default_bin
+        if len(bin_field) == 1:
+            return next(iter(bin_field))
+        if bin_field:
+            return sorted(bin_field)[0]
+
+    return default_bin
+
+
+def prepare_npx_package(
+    package_spec: str,
+    sandbox: Path,
+    env: dict[str, str],
+    timeout: float,
+) -> str | None:
+    """Install an npm package into the sandbox so postinstall hooks can run."""
+    full_env = os.environ.copy()
+    full_env.update(env)
+
+    try:
+        result = subprocess.run(
+            [
+                "npm",
+                "install",
+                "--no-audit",
+                "--no-fund",
+                "--prefix",
+                str(sandbox),
+                package_spec,
+            ],
+            cwd=sandbox,
+            env=full_env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return f"npm install timed out after {timeout}s"
+    except Exception as exc:  # noqa: BLE001
+        return f"npm install failed: {type(exc).__name__}: {exc}"
+
+    if result.returncode == 0:
+        return None
+
+    combined = "\n".join(
+        line for line in (result.stderr + "\n" + result.stdout).splitlines() if line.strip()
+    )
+    return combined[:400] or f"npm install exited with code {result.returncode}"
+
+
+def build_installed_npx_command(
+    package_spec: str,
+    args: list[str],
+    sandbox: Path,
+    auth_home: Path,
+) -> list[str] | None:
+    """Resolve the best command for an npm package installed into the sandbox."""
+    bin_name = npm_package_bin_name(package_spec, sandbox)
+    candidates = [
+        auth_home / ".local" / "bin" / bin_name,
+        sandbox / "node_modules" / ".bin" / bin_name,
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            ensure_executable(candidate)
+            return [str(candidate)] + args
+
+    return None
+
+
 def verify_binary(agent: dict, sandbox: Path, timeout: int, verbose: bool) -> Result:
     """Verify binary distribution."""
     agent_id = agent["id"]
@@ -179,55 +319,22 @@ def verify_binary(agent: dict, sandbox: Path, timeout: int, verbose: bool) -> Re
     else:
         print("    → Using cached extraction")
 
-    # Find executable
-    if cmd.startswith("./"):
-        cmd = cmd[2:]
-
-    # Check if cmd is a system command (node, python, etc.)
-    if cmd in ("node", "python", "python3", "java", "ruby"):
-        system_cmd = shutil.which(cmd)
-        if not system_cmd:
+    exe_path = resolve_binary_executable(extract_dir, cmd)
+    if exe_path is None:
+        return Result(agent_id, "binary", False, f"Executable not found: {cmd}")
+    if not exe_path.exists():
+        normalized_cmd = normalize_command_path(cmd)
+        if normalized_cmd in SYSTEM_COMMANDS:
             return Result(
                 agent_id,
                 "binary",
                 False,
-                f"System command not found: {cmd}",
+                f"System command not found: {normalized_cmd}",
                 skipped=True,
             )
-        # For system commands, the working directory should be the extract_dir
-        exe_path = Path(system_cmd)
-        # Args should reference files in extract_dir
-    else:
-        # Look for the executable (might be in subdirectory)
-        exe_path = None
+        return Result(agent_id, "binary", False, f"Executable not found: {normalized_cmd}")
 
-        # First try exact match
-        for path in extract_dir.rglob(cmd):
-            exe_path = path
-            break
-
-        # If not found, try raw binary (file downloaded without archive)
-        if not exe_path:
-            # Check if there's only one file in extract_dir (raw binary case)
-            files_in_extract = list(extract_dir.iterdir())
-            if len(files_in_extract) == 1 and files_in_extract[0].is_file():
-                # Rename the raw binary to expected name
-                raw_file = files_in_extract[0]
-                expected_path = extract_dir / cmd
-                if not expected_path.exists():
-                    raw_file.rename(expected_path)
-                exe_path = expected_path
-
-        if not exe_path:
-            # Try direct path
-            exe_path = extract_dir / cmd
-
-        if not exe_path.exists():
-            return Result(agent_id, "binary", False, f"Executable not found: {cmd}")
-
-    # Make executable on Unix
-    if platform.system() != "Windows":
-        exe_path.chmod(exe_path.stat().st_mode | 0o755)
+    ensure_executable(exe_path)
 
     # Run
     print(f"    → Running: {exe_path.name} {' '.join(args)}")
@@ -372,6 +479,12 @@ def prepare_binary(agent: dict, sandbox: Path) -> tuple[bool, str]:
         if not extract_archive(archive_path, extract_dir):
             return False, "Extraction failed"
 
+    exe_path = resolve_binary_executable(extract_dir, target.get("cmd", ""))
+    if exe_path is None or not exe_path.exists():
+        return False, f"Executable not found: {normalize_command_path(target.get('cmd', ''))}"
+
+    ensure_executable(exe_path)
+
     return True, "Binary prepared"
 
 
@@ -410,22 +523,13 @@ def build_agent_command(
         env = target.get("env", {})
         extract_dir = sandbox / "extracted"
 
-        # Find the executable
         target_cmd = target.get("cmd", "")
-        if target_cmd.startswith("./"):
-            target_cmd = target_cmd[2:]
-
-        if target_cmd in ("node", "python", "python3", "java", "ruby"):
-            exe_path = Path(shutil.which(target_cmd) or target_cmd)
+        exe_path = resolve_binary_executable(extract_dir, target_cmd)
+        if exe_path is None or not exe_path.exists():
+            cmd = []
         else:
-            exe_path = None
-            for path in extract_dir.rglob(target_cmd):
-                exe_path = path
-                break
-            if not exe_path:
-                exe_path = extract_dir / target_cmd
-
-        cmd = [str(exe_path)] + args
+            ensure_executable(exe_path)
+            cmd = [str(exe_path)] + args
         cwd = extract_dir
     else:
         cmd = []
@@ -477,6 +581,17 @@ def verify_auth(
         if not success:
             return Result(agent_id, dist_type, False, message, skipped=True)
 
+    # Create isolated environment with sandbox HOME
+    auth_sandbox = sandbox / "auth-home"
+    auth_sandbox.mkdir(exist_ok=True)
+    env = {
+        "HOME": str(auth_sandbox),
+    }
+    auth_path_entries = [
+        str(auth_sandbox / ".local" / "bin"),
+        str(sandbox / "node_modules" / ".bin"),
+    ]
+
     # Build command for this distribution
     cmd, cwd, agent_env = build_agent_command(agent, dist_type, sandbox)
 
@@ -485,13 +600,8 @@ def verify_auth(
             agent_id, dist_type, False, f"Cannot build command for {dist_type}", skipped=True
         )
 
-    # Create isolated environment with sandbox HOME
-    auth_sandbox = sandbox / "auth-home"
-    auth_sandbox.mkdir(exist_ok=True)
-    env = {
-        "HOME": str(auth_sandbox),
-        **agent_env,
-    }
+    env.update(agent_env)
+    env["PATH"] = os.pathsep.join(auth_path_entries + [env.get("PATH", os.environ.get("PATH", ""))])
 
     if verbose:
         print(f"    → Auth check: {' '.join(cmd[:3])}...")
@@ -505,6 +615,33 @@ def verify_auth(
 
     # Print diagnostics for failed attempt
     _print_auth_diagnostics(result)
+
+    if dist_type == "npx" and should_retry_npx_auth_with_install(result.error, result.stderr_tail):
+        npx_dist = agent["distribution"].get("npx", {})
+        package = npx_dist.get("package", "")
+        args = npx_dist.get("args", [])
+
+        print("    Installing package into sandbox and retrying...")
+        install_error = prepare_npx_package(package, sandbox, env, auth_timeout)
+        if install_error is not None:
+            return Result(agent_id, dist_type, False, install_error)
+
+        installed_cmd = build_installed_npx_command(package, args, sandbox, auth_sandbox)
+        if installed_cmd is None:
+            return Result(
+                agent_id,
+                dist_type,
+                False,
+                f"Installed package did not expose a runnable binary: {package}",
+            )
+
+        result = run_auth_check(installed_cmd, sandbox, env, auth_timeout)
+        if result.success:
+            methods_info = ", ".join(f"{m.id}({m.type})" for m in result.auth_methods if m.type)
+            return Result(agent_id, dist_type, True, f"Auth OK (installed): {methods_info}")
+
+        _print_auth_diagnostics(result)
+        return Result(agent_id, dist_type, False, result.error or "Auth check failed")
 
     # Retry once for transient failures
     print("    Retrying...")
@@ -609,7 +746,7 @@ def load_registry(registry_dir: Path) -> list[dict]:
     quarantine = load_quarantine(registry_dir)
 
     for agent_dir in sorted(registry_dir.iterdir()):
-        if not agent_dir.is_dir() or agent_dir.name in SKIP_DIRS:
+        if not agent_dir.is_dir() or should_skip_dir(agent_dir.name):
             continue
 
         agent_json = agent_dir / "agent.json"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,14 @@ dist/
 .sandbox/
 .matrix-sandbox/
 .docker-state/
+.sandbox-*/
+.matrix-sandbox-*/
+
+# Local protocol-matrix/debug output
+.protocol-matrix-*/
+.tmp-*/
+.tmp-*.out
+.tmp-*.err
 
 # Python
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,10 @@ python .github/workflows/build_registry.py
 ## Testing & Linting
 
 ```bash
-# Run tests
+# Run workflow tests in the Dockerized local environment (recommended)
+.github/workflows/scripts/run-workflows-tests.sh
+
+# Run workflow tests natively on the host (CI-style debugging only)
 cd .github/workflows && uv run --with pytest pytest tests/ -v
 
 # Lint check
@@ -36,6 +39,9 @@ cd .github/workflows && uv run --with ruff ruff format .
 GitHub Actions runs the nightly protocol matrix natively on the runner (`uv` + Node.js installed in the workflow), but local verification can still use Docker to keep downloads, caches, and auth-related state isolated from your host machine:
 
 ```bash
+# Run workflow tests in the Dockerized local environment
+.github/workflows/scripts/run-workflows-tests.sh
+
 # Validate schema/build output in a container
 .github/workflows/scripts/run-registry-docker.sh uv run --with jsonschema .github/workflows/build_registry.py
 
@@ -52,7 +58,9 @@ GitHub Actions runs the nightly protocol matrix natively on the runner (`uv` + N
 .github/workflows/scripts/run-protocol-matrix.sh --table-mode capabilities --changed-only
 ```
 
-The container keeps state under `.docker-state/` in the repo and disables Python keyring backends to avoid host keychain prompts during local verification.
+`run-protocol-matrix.sh` mirrors the scheduled GitHub Actions defaults: it uses `--table-mode capabilities` and creates ephemeral isolated Docker state plus a fresh protocol sandbox by default so agents cannot reuse local login/keychain state or stale install artifacts across runs. Set `ACP_PROTOCOL_MATRIX_KEEP_STATE=1` if you intentionally want to keep the container state and `.matrix-sandbox` for debugging.
+
+The generic Docker wrapper keeps state under `.docker-state/` in the repo, defaults to `linux/amd64` to match `ubuntu-latest`, injects a passwd entry for the current UID inside the container, and disables Python keyring backends to avoid host keychain prompts during local verification. It reuses an existing local Docker image when the requested platform and image inputs still match, and rebuilds automatically when they do not; set `ACP_REGISTRY_BUILD_IMAGE=1` to force a rebuild. Treat the Docker wrappers as the canonical local path; use host-native `uv run ...` commands only when you intentionally want to debug outside the container. Set `ACP_REGISTRY_DOCKER_PLATFORM=` to opt out of the default platform override when you explicitly want native-architecture debugging.
 Set `ACP_PROTOCOL_MATRIX_SKIP_AGENTS=crow-cli` to skip specific agents during matrix generation.
 
 ## Architecture


### PR DESCRIPTION
## Summary
- align the local Dockerized workflow tooling with the GitHub Actions environment
- harden protocol/auth verification for agents that need extra setup before initialize
- reduce local scratch-directory noise by moving temp state under ignored sandboxes and skipping hidden dirs during registry scans

## Changes
- add a Docker entrypoint plus image/platform fingerprinting so the local registry image is rebuilt when needed
- remove the hidden default `crow-cli` skip from protocol-matrix runs
- add timeout/exit-grace handling in `protocol_matrix.py` and regression coverage
- teach `verify_agents.py` to make binary artifacts executable before auth checks and to install npm packages like `junie` into the sandbox when the shim-based auth path requires it
- add Dockerized workflow test wrapper scripts and update local workflow docs
- ignore and skip hidden runtime/debug directories to keep local runs and build output quiet

## Validation
- `./.github/workflows/scripts/run-registry-docker.sh /bin/sh -lc 'cd /workspace/.github/workflows && uv run --no-project --with ruff ruff check . && uv run --no-project --with ruff ruff format --check . && uv run --no-project --with pytest pytest tests/ -v'`
- `./.github/workflows/scripts/run-registry-docker.sh python3 .github/workflows/verify_agents.py --auth-check`
- `./.github/workflows/scripts/run-registry-docker.sh uv run --with jsonschema .github/workflows/build_registry.py`
