### PR TITLE
ci: serialize workflows that push to main

### DIFF
--- a/.github/workflows/daily-protocol-matrix.yml
+++ b/.github/workflows/daily-protocol-matrix.yml
@@ -2,8 +2,8 @@ name: Nightly Protocol Matrix
 
 on:
   schedule:
-    # Run nightly at 05:00 UTC
-    - cron: "0 5 * * *"
+    # Run nightly after the hourly version update workflow.
+    - cron: "15 5 * * *"
   workflow_dispatch:
     inputs:
       agents:
@@ -34,6 +34,9 @@ permissions:
 
 jobs:
   generate:
+    concurrency:
+      group: registry-main-write
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -128,6 +128,9 @@ jobs:
   apply-updates:
     needs: check-versions
     if: needs.check-versions.outputs.has_updates == 'true' && (github.event_name == 'schedule' || inputs.apply == true || inputs.apply == 'true')
+    concurrency:
+      group: registry-main-write
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- add a shared concurrency group for the jobs that push commits back to `main`
- move the nightly protocol matrix schedule to 05:15 UTC so it runs after the hourly version updater
- prevent the `Nightly Protocol Matrix` workflow from failing with a non-fast-forward push when another scheduled workflow updated `main` first

## Validation
- load both workflow YAML files successfully
- run `git diff --check`