### PR TITLE
Enable Claude Code ACP in registry-for-jetbrains.json

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -563,9 +563,11 @@ def build_registry(dry_run: bool = False):
 
     # Agents excluded from registry.json (default registry)
     DEFAULT_EXCLUDE_IDS = {"github-copilot"}
-    default_agents = [a for a in agents if a["id"] not in DEFAULT_EXCLUDE_IDS]    # Agents excluded from registry-for-jetbrains.json
+    default_agents = [a for a in agents if a["id"] not in DEFAULT_EXCLUDE_IDS]
 
+    # Agents excluded from registry-for-jetbrains.json
     JETBRAINS_EXCLUDE_IDS = {"codex-acp", "junie", "github-copilot-cli"}
+
     def patch_agent_for_jetbrains(agent):
         if agent["id"] == "claude-acp":
             assert "npx" in agent["distribution"], "claude-acp must have npx distribution"
@@ -573,7 +575,9 @@ def build_registry(dry_run: bool = False):
             agent["distribution"]["npx"].setdefault("args", []).append("--hide-claude-auth")
         return agent
 
-    jetbrains_agents = [patch_agent_for_jetbrains(a) for a in agents if a["id"] not in JETBRAINS_EXCLUDE_IDS]
+    jetbrains_agents = [
+        patch_agent_for_jetbrains(a) for a in agents if a["id"] not in JETBRAINS_EXCLUDE_IDS
+    ]
 
     if dry_run:
         print(f"\nDry run: validated {len(agents)} agents successfully")


### PR DESCRIPTION
Adds Claude Code to `registry-for-jetbrains.json` without `Log in with Claude` authentication.


Expected diff `registry-for-jetbrains.json`:
```
diff dist/registry-for-jetbrains.json.baseline dist/registry-for-jetbrains.json.updated
80a81,100
>       "id": "claude-acp",
>       "name": "Claude Agent",
>       "version": "0.21.0",
>       "description": "ACP wrapper for Anthropic's Claude",
>       "repository": "https://github.com/zed-industries/claude-agent-acp",
>       "authors": [
>         "Anthropic"
>       ],
>       "license": "proprietary",
>       "distribution": {
>         "npx": {
>           "package": "@zed-industries/claude-agent-acp@0.21.0",
>           "args": [
>             "--hide-claude-auth"
>           ]
>         }
>       },
>       "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/claude-acp.svg"
>     },
>     {
```

Tested acp config: no `Log in with Claude` authentication method is suggested.
```
    "Claude - npx": {
      "command": "npx",
      "args": [
        "-y",
        "@zed-industries/claude-agent-acp@0.21",
        "--hide-claude-auth"
      ]
    }
  }
```