### PR TITLE
Bump minion-code to 0.1.44

### DIFF
--- a/minion-code/agent.json
+++ b/minion-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "minion-code",
   "name": "Minion Code",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "An enhanced AI code assistant built on the Minion framework with rich development tools",
   "repository": "https://github.com/femto/minion-code",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "AGPL-3.0",
   "distribution": {
     "uvx": {
-      "package": "minion-code@0.1.43",
+      "package": "minion-code@0.1.44",
       "args": [
         "acp"
       ]


### PR DESCRIPTION
## Summary
- bump `minion-code` registry entry from `0.1.39` to `0.1.44`
- update the `uvx` package reference to `minion-code@0.1.44`

