### PR TITLE
feat: add/update argy-code v1.3.5

### DIFF
--- a/argy-code/agent.json
+++ b/argy-code/agent.json
@@ -1,0 +1,56 @@
+{
+  "id": "argy-code",
+  "name": "Argy Code",
+  "version": "1.3.5",
+  "description": "The AI coding agent for the terminal, powered by the Argy platform",
+  "repository": "https://github.com/demkada/argy-code",
+  "authors": [
+    "Argy Cloud <support@argy.cloud>"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/demkada/argy-code/releases/download/v1.3.5/argy-darwin-arm64.zip",
+        "cmd": "./argy",
+        "args": [
+          "acp"
+        ]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/demkada/argy-code/releases/download/v1.3.5/argy-darwin-x64.zip",
+        "cmd": "./argy",
+        "args": [
+          "acp"
+        ]
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/demkada/argy-code/releases/download/v1.3.5/argy-linux-arm64.tar.gz",
+        "cmd": "./argy",
+        "args": [
+          "acp"
+        ]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/demkada/argy-code/releases/download/v1.3.5/argy-linux-x64.tar.gz",
+        "cmd": "./argy",
+        "args": [
+          "acp"
+        ]
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/demkada/argy-code/releases/download/v1.3.5/argy-windows-x64.zip",
+        "cmd": "argy.exe",
+        "args": [
+          "acp"
+        ]
+      }
+    },
+    "npx": {
+      "package": "@argy-cloud/code@1.3.5",
+      "args": [
+        "acp"
+      ]
+    }
+  }
+}

--- a/argy-code/icon.svg
+++ b/argy-code/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 1L1 15h2.5l1.2-2.8h6.6L12.5 15H15L8 1zm0 3.4L10.7 11H5.3L8 4.4z"/>
+</svg>


### PR DESCRIPTION
## Argy Code v1.3.5

The AI coding agent for the terminal, powered by the Argy platform.

- **Repository**: https://github.com/demkada/argy-code
- **npm**: `@argy-cloud/code@1.3.5`
- **Binary releases**: macOS (arm64/x64), Linux (arm64/x64), Windows (x64)
- **ACP command**: `argy acp`

Authentication is handled via `argy auth login` (device code flow) or `ARGY_PAT` env var.
