### PR TITLE
ci: allow workflow_dispatch to trigger S3 upload and release

### DIFF
--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -76,7 +76,7 @@ jobs:
         run: ls -la dist/
 
       - name: Upload artifacts
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
           name: registry
@@ -111,7 +111,7 @@ jobs:
   upload:
     name: Upload to S3
     needs: [build, verify-auth]
-    if: always() && !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: always() && !failure() && !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       S3_PREFIX: registry/v1
@@ -164,7 +164,7 @@ jobs:
   release:
     name: Publish GitHub Release
     needs: [build, verify-auth]
-    if: always() && !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: always() && !failure() && !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- The S3 upload, artifact upload, and GitHub release jobs were gated on `github.event_name == 'push'`, causing them to be skipped on manual `workflow_dispatch` runs
- Added `|| github.event_name == 'workflow_dispatch'` to all three conditions so manual triggers on main also deploy to CDN and publish releases

## Test plan
- [ ] Merge this PR, then trigger `workflow_dispatch` on main and verify S3 upload + release jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)