### PR TITLE
[codex] Add registry archive bootstrap and sync checks

### DIFF
--- a/.github/workflows/backfill_registry_archive.py
+++ b/.github/workflows/backfill_registry_archive.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Backfill registry-archive.json from published GitHub release snapshots.
+
+This script downloads historical ``registry.json`` assets from published GitHub
+releases and merges them into a single archive grouped by agent id.
+
+Usage:
+    python .github/workflows/backfill_registry_archive.py
+
+    python .github/workflows/backfill_registry_archive.py \
+      --output /tmp/registry-archive.json
+
+Environment variables:
+    GITHUB_TOKEN: Optional GitHub token for the releases API.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import NamedTuple
+
+from registry_archive import build_archive_from_snapshots
+
+DEFAULT_REPOSITORY = "agentclientprotocol/registry"
+DEFAULT_OUTPUT_NAME = "registry-archive.json"
+GITHUB_API_BASE_URL = "https://api.github.com"
+USER_AGENT = "ACP-Registry-Archive-Backfill/1.0"
+
+
+class ReleaseSnapshot(NamedTuple):
+    """Published registry snapshot metadata."""
+
+    tag_name: str
+    published_at: str
+    download_url: str
+
+
+def get_github_token() -> str | None:
+    """Return GitHub token from the environment if present."""
+    return os.environ.get("GITHUB_TOKEN")
+
+
+def request_json(url: str) -> dict | list:
+    """Fetch and decode JSON from a URL."""
+    headers = {"User-Agent": USER_AGENT}
+    token = get_github_token()
+    if token and "api.github.com" in url:
+        headers["Authorization"] = f"token {token}"
+
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as response:
+        return json.loads(response.read())
+
+
+def find_registry_asset_url(release: dict) -> str | None:
+    """Return the download URL for the registry.json asset in a release."""
+    assets = release.get("assets", [])
+    if not isinstance(assets, list):
+        raise ValueError("Release assets payload must be a list")
+
+    for asset in assets:
+        if asset.get("name") == "registry.json":
+            download_url = asset.get("browser_download_url")
+            if not isinstance(download_url, str) or not download_url:
+                raise ValueError("registry.json asset is missing browser_download_url")
+            return download_url
+    return None
+
+
+def fetch_release_snapshots(repository: str) -> list[ReleaseSnapshot]:
+    """Fetch published releases that contain a registry.json asset."""
+    snapshots: list[ReleaseSnapshot] = []
+    page = 1
+
+    while True:
+        url = f"{GITHUB_API_BASE_URL}/repos/{repository}/releases?per_page=100&page={page}"
+        payload = request_json(url)
+        if not isinstance(payload, list):
+            raise ValueError("GitHub releases API returned a non-list payload")
+        if not payload:
+            break
+
+        for release in payload:
+            if release.get("draft") or release.get("prerelease"):
+                continue
+
+            download_url = find_registry_asset_url(release)
+            if not download_url:
+                continue
+
+            tag_name = release.get("tag_name")
+            published_at = release.get("published_at")
+            if not isinstance(tag_name, str) or not tag_name:
+                raise ValueError("Published release is missing tag_name")
+            if not isinstance(published_at, str) or not published_at:
+                raise ValueError(f"Release {tag_name} is missing published_at")
+
+            snapshots.append(
+                ReleaseSnapshot(
+                    tag_name=tag_name,
+                    published_at=published_at,
+                    download_url=download_url,
+                )
+            )
+
+        page += 1
+
+    snapshots.sort(key=lambda snapshot: (snapshot.published_at, snapshot.tag_name))
+    return snapshots
+
+
+def fetch_registry_snapshot(snapshot: ReleaseSnapshot) -> dict:
+    """Download a published registry.json snapshot."""
+    payload = request_json(snapshot.download_url)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{snapshot.tag_name} registry.json is not a JSON object")
+
+    agents = payload.get("agents")
+    if not isinstance(agents, list):
+        raise ValueError(f"{snapshot.tag_name} registry.json is missing an agents list")
+
+    return payload
+
+
+def get_default_output_path() -> Path:
+    """Return the default output path under dist/."""
+    registry_dir = Path(__file__).parent.parent.parent
+    return registry_dir / "dist" / DEFAULT_OUTPUT_NAME
+
+
+def write_archive(output_path: Path, archive: dict) -> None:
+    """Write the archive JSON file."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(archive, indent=2) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Backfill registry-archive.json from published release snapshots"
+    )
+    parser.add_argument(
+        "--repository",
+        default=DEFAULT_REPOSITORY,
+        help=f"GitHub repository in owner/name form (default: {DEFAULT_REPOSITORY})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=get_default_output_path(),
+        help="Path to write registry-archive.json",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the backfill process."""
+    args = parse_args()
+
+    snapshots = fetch_release_snapshots(args.repository)
+    if not snapshots:
+        print("No published releases with registry.json assets were found", file=sys.stderr)
+        return 1
+
+    registries = []
+    total_snapshots = len(snapshots)
+    for index, snapshot in enumerate(snapshots, start=1):
+        if index == 1 or index == total_snapshots or index % 25 == 0:
+            print(
+                f"Fetching snapshot {index}/{total_snapshots}: {snapshot.tag_name}",
+                file=sys.stderr,
+            )
+        registries.append(fetch_registry_snapshot(snapshot))
+
+    archive = build_archive_from_snapshots(registries)
+    write_archive(args.output, archive)
+
+    total_versions = sum(len(agent["versions"]) for agent in archive["agents"])
+    print(
+        f"Wrote {args.output} with {len(archive['agents'])} agents and "
+        f"{total_versions} archived versions",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except urllib.error.HTTPError as exc:
+        print(f"HTTP error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except urllib.error.URLError as exc:
+        print(f"Network error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/.github/workflows/bootstrap/registry-archive.seed.json
+++ b/.github/workflows/bootstrap/registry-archive.seed.json
@@ -1,0 +1,21762 @@
+{
+  "version": "1.0.0",
+  "agents": [
+    {
+      "id": "amp-acp",
+      "versions": [
+        {
+          "id": "amp-acp",
+          "name": "Amp",
+          "version": "0.7.0",
+          "description": "ACP wrapper for Amp - the frontier coding agent",
+          "repository": "https://github.com/tao12345666333/amp-acp",
+          "authors": [
+            "tao12345666333"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-darwin-aarch64.tar.gz",
+                "cmd": "./amp-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-darwin-x86_64.tar.gz",
+                "cmd": "./amp-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-linux-aarch64.tar.gz",
+                "cmd": "./amp-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-linux-x86_64.tar.gz",
+                "cmd": "./amp-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.7.0/amp-acp-windows-x86_64.zip",
+                "cmd": "amp-acp.exe"
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/amp-acp.svg"
+    },
+    {
+      "id": "auggie",
+      "versions": [
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.2.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "darwin-x86_64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "linux-aarch64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "linux-x86_64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "windows-x86_64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              }
+            },
+            "bunx": {
+              "package": "@augmentcode/auggie@0.9.1",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            },
+            "npx": {
+              "package": "@augmentcode/auggie@0.9.1",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.9.1",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "darwin-x86_64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "linux-aarch64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "linux-x86_64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              },
+              "windows-x86_64": {
+                "archive": "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.9.1.tgz",
+                "cmd": "node",
+                "args": [
+                  "./package/augment.mjs",
+                  "--acp"
+                ],
+                "env": {
+                  "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+                }
+              }
+            },
+            "npx": {
+              "package": "@augmentcode/auggie@0.9.1",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.12.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.12.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.13.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.13.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.14.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.14.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.15.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.15.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.16.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.16.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.16.1",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.16.1",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.16.2",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.16.2",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.17.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.17.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.17.1",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.17.1",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.17.2",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.17.2",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.18.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.18.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.18.1",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.18.1",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.19.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie-zed-extension",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.19.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.20.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie",
+          "website": "https://www.augmentcode.com/",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.20.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.20.1",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie",
+          "website": "https://www.augmentcode.com/",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.20.1",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.21.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie",
+          "website": "https://www.augmentcode.com/",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.21.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.22.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie",
+          "website": "https://www.augmentcode.com/",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.22.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.23.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie",
+          "website": "https://www.augmentcode.com/",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.23.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        },
+        {
+          "id": "auggie",
+          "name": "Auggie CLI",
+          "version": "0.24.0",
+          "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
+          "repository": "https://github.com/augmentcode/auggie",
+          "website": "https://www.augmentcode.com/",
+          "authors": [
+            "Augment Code <support@augmentcode.com>"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@augmentcode/auggie@0.24.0",
+              "args": [
+                "--acp"
+              ],
+              "env": {
+                "AUGMENT_DISABLE_AUTO_UPDATE": "1"
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/auggie.svg"
+    },
+    {
+      "id": "autohand",
+      "versions": [
+        {
+          "id": "autohand",
+          "name": "Autohand Code",
+          "version": "0.2.1",
+          "description": "Autohand Code - AI coding agent powered by Autohand AI",
+          "repository": "https://github.com/autohandai/autohand-acp",
+          "website": "https://www.autohand.ai/cli/",
+          "authors": [
+            "Autohand AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@autohandai/autohand-acp@0.2.1"
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/autohand.svg"
+    },
+    {
+      "id": "cagent",
+      "versions": [
+        {
+          "id": "cagent",
+          "name": "Docker cagent",
+          "version": "1.15.3",
+          "description": "Docker's AI coding agent",
+          "repository": "https://github.com/docker/cagent",
+          "authors": [
+            "Docker"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.3/cagent-darwin-arm64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.3/cagent-darwin-amd64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.3/cagent-linux-arm64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.3/cagent-linux-amd64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.3/cagent-windows-arm64.exe",
+                "cmd": "./cagent.exe",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.3/cagent-windows-amd64.exe",
+                "cmd": "./cagent.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "cagent",
+          "name": "Docker cagent",
+          "version": "1.15.8",
+          "description": "Docker's AI coding agent",
+          "repository": "https://github.com/docker/cagent",
+          "authors": [
+            "Docker"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.8/cagent-darwin-arm64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.8/cagent-darwin-amd64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.8/cagent-linux-arm64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.8/cagent-linux-amd64",
+                "cmd": "./cagent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.8/cagent-windows-arm64.exe",
+                "cmd": "./cagent.exe",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/docker/cagent/releases/download/v1.15.8/cagent-windows-amd64.exe",
+                "cmd": "./cagent.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://github.com/agentclientprotocol/registry/releases/latest/download/cagent.svg"
+    },
+    {
+      "id": "claude",
+      "versions": [
+        {
+          "id": "claude",
+          "name": "Claude Code",
+          "version": "0.12.6",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-code-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp@0.12.6"
+            }
+          }
+        }
+      ],
+      "icon": "https://github.com/agentclientprotocol/registry/releases/latest/download/claude.svg"
+    },
+    {
+      "id": "claude-acp",
+      "versions": [
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.17.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.17.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.17.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.17.1"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.18.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.18.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.19.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.1/claude-agent-acp-darwin-arm64.zip",
+                "cmd": "./claude-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.1/claude-agent-acp-darwin-x64.zip",
+                "cmd": "./claude-agent-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.1/claude-agent-acp-linux-arm64.tar.gz",
+                "cmd": "./claude-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.1/claude-agent-acp-linux-x64.tar.gz",
+                "cmd": "./claude-agent-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.1/claude-agent-acp-windows-arm64.zip",
+                "cmd": "./claude-agent-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/claude-agent-acp/releases/download/v0.19.1/claude-agent-acp-windows-x64.zip",
+                "cmd": "./claude-agent-acp.exe"
+              }
+            },
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.19.1"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.19.2",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.19.2"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.20.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.20.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.20.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.20.1"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.20.2",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.20.2"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.21.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.21.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.22.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.22.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.22.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.22.1"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.22.2",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.22.2"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.23.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-agent-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-agent-acp@0.23.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.24.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.24.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.24.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.24.1"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.24.2",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.24.2"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.25.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.25.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.25.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.25.1"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.25.3",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.25.3"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.26.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.26.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.27.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.27.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.28.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.28.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.29.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.29.0"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.29.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.29.1"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.29.2",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.29.2"
+            }
+          }
+        },
+        {
+          "id": "claude-acp",
+          "name": "Claude Agent",
+          "version": "0.30.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
+          "authors": [
+            "Anthropic",
+            "Zed Industries",
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@agentclientprotocol/claude-agent-acp@0.30.0"
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/claude-acp.svg"
+    },
+    {
+      "id": "claude-code",
+      "versions": [
+        {
+          "id": "claude-code",
+          "name": "Claude Code",
+          "version": "0.12.6",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/anthropics/claude-code",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp"
+            }
+          }
+        }
+      ],
+      "icon": "https://github.com/agentclientprotocol/registry/releases/latest/download/claude-code.svg"
+    },
+    {
+      "id": "claude-code-acp",
+      "versions": [
+        {
+          "id": "claude-code-acp",
+          "name": "Claude Code",
+          "version": "0.13.2",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-code-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp@0.13.2"
+            }
+          }
+        },
+        {
+          "id": "claude-code-acp",
+          "name": "Claude Code",
+          "version": "0.14.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-code-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp@0.14.0"
+            }
+          }
+        },
+        {
+          "id": "claude-code-acp",
+          "name": "Claude Code",
+          "version": "0.15.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-code-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp@0.15.0"
+            }
+          }
+        },
+        {
+          "id": "claude-code-acp",
+          "name": "Claude Code",
+          "version": "0.16.0",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-code-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp@0.16.0"
+            }
+          }
+        },
+        {
+          "id": "claude-code-acp",
+          "name": "Claude Code",
+          "version": "0.16.1",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-code-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp@0.16.1"
+            }
+          }
+        },
+        {
+          "id": "claude-code-acp",
+          "name": "Claude Code",
+          "version": "0.16.2",
+          "description": "ACP wrapper for Anthropic's Claude",
+          "repository": "https://github.com/zed-industries/claude-code-acp",
+          "authors": [
+            "Anthropic"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@zed-industries/claude-code-acp@0.16.2"
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/claude-code-acp.svg"
+    },
+    {
+      "id": "cline",
+      "versions": [
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.2.2",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.2.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.2.3",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.2.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.3.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.3.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.4.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.4.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.4.1",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.4.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.4.2",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.4.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.4.3",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.4.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.5.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.5.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.5.1",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.5.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.5.2",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.5.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.6.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.6.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.6.1",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.6.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.7.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.7.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.7.1",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.7.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.8.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.8.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.8.1",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "website": "https://cline.bot/cli",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.8.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.8.2",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "website": "https://cline.bot/cli",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.8.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.9.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "website": "https://cline.bot/cli",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.9.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.11.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "website": "https://cline.bot/cli",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.11.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.13.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "website": "https://cline.bot/cli",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.13.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.14.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "website": "https://cline.bot/cli",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.14.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "cline",
+          "name": "Cline",
+          "version": "2.15.0",
+          "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+          "repository": "https://github.com/cline/cline",
+          "website": "https://cline.bot/cli",
+          "authors": [
+            "Cline Bot Inc."
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "cline@2.15.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/cline.svg"
+    },
+    {
+      "id": "code-assistant",
+      "versions": [
+        {
+          "id": "code-assistant",
+          "name": "Code Assistant",
+          "version": "0.1.19",
+          "description": "AI-powered coding assistant",
+          "repository": "https://github.com/stippi/code-assistant",
+          "authors": [
+            "Stephan A\u00dfmus"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.19/code-assistant-macos-aarch64.zip",
+                "cmd": "./code-assistant",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.19/code-assistant-macos-x86_64.zip",
+                "cmd": "./code-assistant",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.19/code-assistant-linux-x86_64.zip",
+                "cmd": "./code-assistant",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.19/code-assistant-windows-x86_64.zip",
+                "cmd": "./code-assistant.exe",
+                "args": [
+                  "--acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "code-assistant",
+          "name": "Code Assistant",
+          "version": "0.1.20",
+          "description": "AI-powered coding assistant",
+          "repository": "https://github.com/stippi/code-assistant",
+          "authors": [
+            "Stephan A\u00dfmus"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.20/code-assistant-macos-aarch64.zip",
+                "cmd": "./code-assistant",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.20/code-assistant-macos-x86_64.zip",
+                "cmd": "./code-assistant",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.20/code-assistant-linux-x86_64.zip",
+                "cmd": "./code-assistant",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stippi/code-assistant/releases/download/v0.1.20/code-assistant-windows-x86_64.zip",
+                "cmd": "./code-assistant.exe",
+                "args": [
+                  "--acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://github.com/agentclientprotocol/registry/releases/latest/download/code-assistant.svg"
+    },
+    {
+      "id": "codebuddy",
+      "versions": [
+        {
+          "id": "codebuddy",
+          "name": "Codebuddy",
+          "version": "2.54.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.54.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/codebuddy.svg"
+    },
+    {
+      "id": "codebuddy-code",
+      "versions": [
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.49.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.49.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.49.5",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.49.5",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.49.6",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.49.6",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.49.7",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.49.7",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.50.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.50.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.50.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.50.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.50.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.50.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.50.3",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.50.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.50.5",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.50.5",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.50.6",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.50.6",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.50.7",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.50.7",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.51.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.51.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.51.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.51.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.51.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.51.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.52.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.52.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.52.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.52.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.52.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.52.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.52.3",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.52.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.52.4",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.52.4",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.52.5",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.52.5",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.52.6",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.52.6",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.53.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.53.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.54.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.54.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.55.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.55.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.55.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.55.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.56.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.56.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.56.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.56.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.61.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.61.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.61.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.61.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.61.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.61.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.61.3",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.61.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.62.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.62.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.62.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.62.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.63.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.63.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.63.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.63.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.63.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.63.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.63.3",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.63.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.63.4",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "repository": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.63.4",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.63.5",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.63.5",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.64.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.64.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.64.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.64.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.64.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.64.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.65.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.65.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.65.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.65.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.66.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.66.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.66.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.66.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.67.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.67.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.68.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.68.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.69.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.69.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.70.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.70.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.70.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.70.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.77.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.77.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.77.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.77.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.78.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.78.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.78.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.78.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.79.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.79.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.81.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.81.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.81.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.81.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.81.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.81.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.85.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.85.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.86.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.86.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.87.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.87.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.88.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.88.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.89.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.89.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.90.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.90.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.91.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.91.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.92.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.92.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.93.0",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.93.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.93.1",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.93.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.93.2",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.93.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "codebuddy-code",
+          "name": "Codebuddy Code",
+          "version": "2.93.3",
+          "description": "Tencent Cloud's official intelligent coding tool",
+          "website": "https://www.codebuddy.cn/cli/",
+          "authors": [
+            "Tencent Cloud"
+          ],
+          "license": "Proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@tencent-ai/codebuddy-code@2.93.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/codebuddy-code.svg"
+    },
+    {
+      "id": "codex",
+      "versions": [
+        {
+          "id": "codex",
+          "name": "Codex CLI",
+          "version": "0.7.3",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.3/codex-acp-0.7.3-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.3/codex-acp-0.7.3-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.3/codex-acp-0.7.3-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.3/codex-acp-0.7.3-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.3/codex-acp-0.7.3-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.3/codex-acp-0.7.3-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex",
+          "name": "Codex CLI",
+          "version": "0.7.4",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://github.com/agentclientprotocol/registry/releases/latest/download/codex.svg"
+    },
+    {
+      "id": "codex-acp",
+      "versions": [
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.7.4",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.7.4/codex-acp-0.7.4-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.8.0",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.0/codex-acp-0.8.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.0/codex-acp-0.8.0-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.0/codex-acp-0.8.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.0/codex-acp-0.8.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.0/codex-acp-0.8.0-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.0/codex-acp-0.8.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.8.1",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.1/codex-acp-0.8.1-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.1/codex-acp-0.8.1-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.1/codex-acp-0.8.1-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.1/codex-acp-0.8.1-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.1/codex-acp-0.8.1-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.1/codex-acp-0.8.1-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.8.2",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.2/codex-acp-0.8.2-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.2/codex-acp-0.8.2-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.2/codex-acp-0.8.2-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.2/codex-acp-0.8.2-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.2/codex-acp-0.8.2-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.8.2/codex-acp-0.8.2-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.9.0",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.0/codex-acp-0.9.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.0/codex-acp-0.9.0-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.0/codex-acp-0.9.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.0/codex-acp-0.9.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.0/codex-acp-0.9.0-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.0/codex-acp-0.9.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.9.1",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.1/codex-acp-0.9.1-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.1/codex-acp-0.9.1-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.1/codex-acp-0.9.1-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.1/codex-acp-0.9.1-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.1/codex-acp-0.9.1-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.1/codex-acp-0.9.1-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.9.2",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.2/codex-acp-0.9.2-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.2/codex-acp-0.9.2-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.2/codex-acp-0.9.2-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.2/codex-acp-0.9.2-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.2/codex-acp-0.9.2-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.2/codex-acp-0.9.2-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.9.3",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.3/codex-acp-0.9.3-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.3/codex-acp-0.9.3-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.3/codex-acp-0.9.3-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.3/codex-acp-0.9.3-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.3/codex-acp-0.9.3-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.3/codex-acp-0.9.3-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            },
+            "npx": {
+              "package": "@zed-industries/codex-acp@0.9.3"
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.9.4",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.4/codex-acp-0.9.4-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.4/codex-acp-0.9.4-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.4/codex-acp-0.9.4-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.4/codex-acp-0.9.4-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.4/codex-acp-0.9.4-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.4/codex-acp-0.9.4-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            },
+            "npx": {
+              "package": "@zed-industries/codex-acp@0.9.4"
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.9.5",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.5/codex-acp-0.9.5-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.5/codex-acp-0.9.5-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.5/codex-acp-0.9.5-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.5/codex-acp-0.9.5-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.5/codex-acp-0.9.5-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.9.5/codex-acp-0.9.5-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            },
+            "npx": {
+              "package": "@zed-industries/codex-acp@0.9.5"
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.10.0",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.10.0/codex-acp-0.10.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.10.0/codex-acp-0.10.0-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.10.0/codex-acp-0.10.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.10.0/codex-acp-0.10.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.10.0/codex-acp-0.10.0-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.10.0/codex-acp-0.10.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            },
+            "npx": {
+              "package": "@zed-industries/codex-acp@0.10.0"
+            }
+          }
+        },
+        {
+          "id": "codex-acp",
+          "name": "Codex CLI",
+          "version": "0.11.1",
+          "description": "ACP adapter for OpenAI's coding assistant",
+          "repository": "https://github.com/zed-industries/codex-acp",
+          "authors": [
+            "OpenAI",
+            "Zed Industries"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.11.1/codex-acp-0.11.1-aarch64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.11.1/codex-acp-0.11.1-x86_64-apple-darwin.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.11.1/codex-acp-0.11.1-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.11.1/codex-acp-0.11.1-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./codex-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.11.1/codex-acp-0.11.1-aarch64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/zed-industries/codex-acp/releases/download/v0.11.1/codex-acp-0.11.1-x86_64-pc-windows-msvc.zip",
+                "cmd": "./codex-acp.exe"
+              }
+            },
+            "npx": {
+              "package": "@zed-industries/codex-acp@0.11.1"
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/codex-acp.svg"
+    },
+    {
+      "id": "corust-agent",
+      "versions": [
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.3.1",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.1/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.1/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.1/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.3.2",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.2/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.2/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.2/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.3.3",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.3/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.3/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.3/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.3.4",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.4/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.4/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.4/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.3.6",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.6/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.6/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.6/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.3.7",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.7/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.7/agent-darwin-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.7/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.7/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.3.8",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.8/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.8/agent-darwin-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.8/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.3.8/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.4.0",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "website": "https://corust.ai/",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.0/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.0/agent-darwin-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.0/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.0/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.4.1",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "website": "https://corust.ai/",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.1/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.1/agent-darwin-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.1/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.1/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.4.2",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "website": "https://corust.ai/",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.2/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.2/agent-darwin-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.2/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.4.2/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.5.0",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "website": "https://corust.ai/",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.0/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.0/agent-darwin-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.0/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.0/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "corust-agent",
+          "name": "Corust Agent",
+          "version": "0.5.1",
+          "description": "Co-building with a seasoned Rust partner.",
+          "repository": "https://github.com/Corust-ai/corust-agent-release",
+          "website": "https://corust.ai/",
+          "authors": [
+            "Corust AI <support@corust.ai>"
+          ],
+          "license": "GPL-3.0-or-later",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.1/agent-darwin-arm64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.1/agent-darwin-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.1/agent-linux-x64.tar.gz",
+                "cmd": "./corust-agent-acp"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Corust-ai/corust-agent-release/releases/download/v0.5.1/agent-windows-x64.zip",
+                "cmd": "./corust-agent-acp.exe"
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/corust-agent.svg"
+    },
+    {
+      "id": "crow-cli",
+      "versions": [
+        {
+          "id": "crow-cli",
+          "name": "crow-cli",
+          "version": "0.1.12",
+          "description": "Minimal ACP Native Coding Agent",
+          "repository": "https://github.com/crow-cli/crow-cli",
+          "authors": [
+            "Thomas Wood"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "uvx": {
+              "package": "crow-cli",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "crow-cli",
+          "name": "crow-cli",
+          "version": "0.1.14",
+          "description": "Minimal ACP Native Coding Agent",
+          "repository": "https://github.com/crow-cli/crow-cli",
+          "authors": [
+            "Thomas Wood"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "uvx": {
+              "package": "crow-cli",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "crow-cli",
+          "name": "crow-cli",
+          "version": "0.1.19",
+          "description": "Minimal ACP Native Coding Agent",
+          "repository": "https://github.com/crow-cli/crow-cli",
+          "website": "https://crow-ai.dev",
+          "authors": [
+            "Thomas Wood"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.19/crow-cli-darwin-aarch64.tar.gz",
+                "cmd": "./crow-cli",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.19/crow-cli-darwin-x86_64.tar.gz",
+                "cmd": "./crow-cli",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.19/crow-cli-linux-aarch64.tar.gz",
+                "cmd": "./crow-cli",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.19/crow-cli-linux-x86_64.tar.gz",
+                "cmd": "./crow-cli",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.19/crow-cli-windows-x86_64.zip",
+                "cmd": "./crow-cli.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/crow-cli.svg"
+    },
+    {
+      "id": "cursor",
+      "versions": [
+        {
+          "id": "cursor",
+          "name": "Cursor",
+          "version": "0.1.0",
+          "description": "Cursor's coding agent",
+          "website": "https://cursor.com/docs/cli/acp",
+          "authors": [
+            "Cursor"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.05-2bf2031/darwin/arm64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.05-2bf2031/darwin/x64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.05-2bf2031/linux/arm64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.05-2bf2031/linux/x64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-aarch64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.05-2bf2031/windows/arm64/agent-cli-package.zip",
+                "cmd": "./dist-package\\cursor-agent.cmd",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.05-2bf2031/windows/x64/agent-cli-package.zip",
+                "cmd": "./dist-package\\cursor-agent.cmd",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "cursor",
+          "name": "Cursor",
+          "version": "2026.03.30",
+          "description": "Cursor's coding agent",
+          "website": "https://cursor.com/docs/cli/acp",
+          "authors": [
+            "Cursor"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.30-a5d3e17/darwin/arm64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.30-a5d3e17/darwin/x64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.30-a5d3e17/linux/arm64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.30-a5d3e17/linux/x64/agent-cli-package.tar.gz",
+                "cmd": "./dist-package/cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-aarch64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.30-a5d3e17/windows/arm64/agent-cli-package.zip",
+                "cmd": "./dist-package\\cursor-agent.cmd",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://downloads.cursor.com/lab/2026.03.30-a5d3e17/windows/x64/agent-cli-package.zip",
+                "cmd": "./dist-package\\cursor-agent.cmd",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/cursor.svg"
+    },
+    {
+      "id": "cursor-acp",
+      "versions": [
+        {
+          "id": "cursor-acp",
+          "name": "Cursor",
+          "version": "0.1.0",
+          "description": "ACP for Cursor's coding agent",
+          "authors": [
+            "Cursor"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://anysphere-binaries.s3.amazonaws.com/lab/2026.03.04-c28b141/darwin/arm64/agent-cli-package.tar.gz",
+                "cmd": "./cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://anysphere-binaries.s3.amazonaws.com/lab/2026.03.04-c28b141/darwin/x64/agent-cli-package.tar.gz",
+                "cmd": "./cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://anysphere-binaries.s3.amazonaws.com/lab/2026.03.04-c28b141/linux/arm64/agent-cli-package.tar.gz",
+                "cmd": "./cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://anysphere-binaries.s3.amazonaws.com/lab/2026.03.04-c28b141/linux/x64/agent-cli-package.tar.gz",
+                "cmd": "./cursor-agent",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-aarch64": {
+                "archive": "https://anysphere-binaries.s3.amazonaws.com/lab/2026.03.04-c28b141/windows/arm64/agent-cli-package.zip",
+                "cmd": "./cursor-agent.cmd",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://anysphere-binaries.s3.amazonaws.com/lab/2026.03.04-c28b141/windows/x64/agent-cli-package.zip",
+                "cmd": "./cursor-agent.cmd",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/cursor-acp.svg"
+    },
+    {
+      "id": "deepagents",
+      "versions": [
+        {
+          "id": "deepagents",
+          "name": "DeepAgents",
+          "version": "0.1.1",
+          "description": "Batteries-included AI coding and general purpose agent powered by LangChain.",
+          "repository": "https://github.com/langchain-ai/deepagentsjs",
+          "authors": [
+            "LangChain"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "deepagents-acp@0.1.1",
+              "args": []
+            }
+          }
+        },
+        {
+          "id": "deepagents",
+          "name": "DeepAgents",
+          "version": "0.1.2",
+          "description": "Batteries-included AI coding and general purpose agent powered by LangChain.",
+          "repository": "https://github.com/langchain-ai/deepagentsjs",
+          "authors": [
+            "LangChain"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "deepagents-acp@0.1.2",
+              "args": []
+            }
+          }
+        },
+        {
+          "id": "deepagents",
+          "name": "DeepAgents",
+          "version": "0.1.3",
+          "description": "Batteries-included AI coding and general purpose agent powered by LangChain.",
+          "repository": "https://github.com/langchain-ai/deepagentsjs",
+          "website": "https://docs.langchain.com/oss/javascript/deepagents/overview",
+          "authors": [
+            "LangChain"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "deepagents-acp@0.1.3",
+              "args": []
+            }
+          }
+        },
+        {
+          "id": "deepagents",
+          "name": "DeepAgents",
+          "version": "0.1.4",
+          "description": "Batteries-included AI coding and general purpose agent powered by LangChain.",
+          "repository": "https://github.com/langchain-ai/deepagentsjs",
+          "website": "https://docs.langchain.com/oss/javascript/deepagents/overview",
+          "authors": [
+            "LangChain"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "deepagents-acp@0.1.4",
+              "args": []
+            }
+          }
+        },
+        {
+          "id": "deepagents",
+          "name": "DeepAgents",
+          "version": "0.1.5",
+          "description": "Batteries-included AI coding and general purpose agent powered by LangChain.",
+          "repository": "https://github.com/langchain-ai/deepagentsjs",
+          "website": "https://docs.langchain.com/oss/javascript/deepagents/overview",
+          "authors": [
+            "LangChain"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "deepagents-acp@0.1.5",
+              "args": []
+            }
+          }
+        },
+        {
+          "id": "deepagents",
+          "name": "DeepAgents",
+          "version": "0.1.6",
+          "description": "Batteries-included AI coding and general purpose agent powered by LangChain.",
+          "repository": "https://github.com/langchain-ai/deepagentsjs",
+          "website": "https://docs.langchain.com/oss/javascript/deepagents/overview",
+          "authors": [
+            "LangChain"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "deepagents-acp@0.1.6",
+              "args": []
+            }
+          }
+        },
+        {
+          "id": "deepagents",
+          "name": "DeepAgents",
+          "version": "0.1.7",
+          "description": "Batteries-included AI coding and general purpose agent powered by LangChain.",
+          "repository": "https://github.com/langchain-ai/deepagentsjs",
+          "website": "https://docs.langchain.com/oss/javascript/deepagents/overview",
+          "authors": [
+            "LangChain"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "deepagents-acp@0.1.7",
+              "args": []
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/deepagents.svg"
+    },
+    {
+      "id": "dimcode",
+      "versions": [
+        {
+          "id": "dimcode",
+          "name": "DimCode",
+          "version": "0.0.13",
+          "description": "A coding agent that puts leading models at your command.",
+          "authors": [
+            "ArcShips"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "dimcode@0.0.13",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "dimcode",
+          "name": "DimCode",
+          "version": "0.0.15",
+          "description": "A coding agent that puts leading models at your command.",
+          "authors": [
+            "ArcShips"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "dimcode@0.0.15",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "dimcode",
+          "name": "DimCode",
+          "version": "0.0.16",
+          "description": "A coding agent that puts leading models at your command.",
+          "authors": [
+            "ArcShips"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "dimcode@0.0.16",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "dimcode",
+          "name": "DimCode",
+          "version": "0.0.17",
+          "description": "A coding agent that puts leading models at your command.",
+          "authors": [
+            "ArcShips"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "dimcode@0.0.17",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "dimcode",
+          "name": "DimCode",
+          "version": "0.0.18",
+          "description": "A coding agent that puts leading models at your command.",
+          "authors": [
+            "ArcShips"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "dimcode@0.0.18",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "dimcode",
+          "name": "DimCode",
+          "version": "0.0.19",
+          "description": "A coding agent that puts leading models at your command.",
+          "authors": [
+            "ArcShips"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "dimcode@0.0.19",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "dimcode",
+          "name": "DimCode",
+          "version": "0.0.20",
+          "description": "A coding agent that puts leading models at your command.",
+          "authors": [
+            "ArcShips"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "dimcode@0.0.20",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/dimcode.svg"
+    },
+    {
+      "id": "factory-droid",
+      "versions": [
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.52.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.52.0/droid-darwin-aarch64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.52.0/droid-darwin-x86_64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.52.0/droid-linux-x86_64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.52.0/droid-linux-aarch64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.52.0/droid-windows-x86_64.zip",
+                "cmd": "./droid.exe",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.56.3",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.56.3/droid-darwin-aarch64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ],
+                "env": {
+                  "DROID_DISABLE_AUTO_UPDATE": "true",
+                  "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+                }
+              },
+              "darwin-x86_64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.56.3/droid-darwin-x86_64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ],
+                "env": {
+                  "DROID_DISABLE_AUTO_UPDATE": "true",
+                  "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+                }
+              },
+              "linux-x86_64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.56.3/droid-linux-x86_64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ],
+                "env": {
+                  "DROID_DISABLE_AUTO_UPDATE": "true",
+                  "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+                }
+              },
+              "linux-aarch64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.56.3/droid-linux-aarch64.tar.gz",
+                "cmd": "./droid",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ],
+                "env": {
+                  "DROID_DISABLE_AUTO_UPDATE": "true",
+                  "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+                }
+              },
+              "windows-x86_64": {
+                "archive": "https://downloads.factory.ai/factory-cli/releases/0.56.3/droid-windows-x86_64.zip",
+                "cmd": "./droid.exe",
+                "args": [
+                  "exec",
+                  "--output-format",
+                  "acp"
+                ],
+                "env": {
+                  "DROID_DISABLE_AUTO_UPDATE": "true",
+                  "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.57.10",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.57.10",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.57.11",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.57.11",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.57.12",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.57.12",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.57.14",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.57.14",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.58.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.58.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.60.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.60.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.61.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.61.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.62.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.62.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.62.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.62.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.63.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.63.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.64.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.64.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.65.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.65.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.65.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.65.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.66.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.66.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.67.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.67.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.68.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.68.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.68.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.68.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.69.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.69.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.70.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.70.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.71.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.71.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.73.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.73.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.74.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.74.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.75.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.75.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.76.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.76.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.77.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.77.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.79.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.79.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.80.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.80.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.81.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.81.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.82.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.82.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.83.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.83.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.84.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.84.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.85.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.85.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.86.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.86.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.88.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.88.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.89.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.89.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.89.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.89.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.90.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.90.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.93.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.93.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.94.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.94.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.94.2",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.94.2",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.95.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.95.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.96.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.96.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.96.2",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.96.2",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.97.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.97.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.99.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.99.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.100.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.100.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.101.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.101.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.102.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.102.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.103.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.103.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.103.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.103.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.104.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.104.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.104.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.104.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.105.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.105.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.105.1",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.105.1",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        },
+        {
+          "id": "factory-droid",
+          "name": "Factory Droid",
+          "version": "0.106.0",
+          "description": "Factory Droid - AI coding agent powered by Factory AI",
+          "website": "https://factory.ai/product/cli",
+          "authors": [
+            "Factory AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "droid@0.106.0",
+              "args": [
+                "exec",
+                "--output-format",
+                "acp"
+              ],
+              "env": {
+                "DROID_DISABLE_AUTO_UPDATE": "true",
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/factory-droid.svg"
+    },
+    {
+      "id": "fast-agent",
+      "versions": [
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.5.8",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.5.8",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.5.9",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.5.9",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.5.10",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.5.10",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.5.11",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.5.11",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.0",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.0",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.1",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.1",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.2",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.2",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.3",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.3",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.4",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.4",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.6",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.6",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.7",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.7",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.8",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.8",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.9",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.9",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.10",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.10",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.11",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.11",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.12",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.12",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.15",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.15",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.16",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.16",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.17",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.17",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.18",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.18",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.19",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.19",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.21",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.21",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        },
+        {
+          "id": "fast-agent",
+          "name": "fast-agent",
+          "version": "0.6.22",
+          "description": "Code and build agents with comprehensive multi-provider support",
+          "repository": "https://github.com/evalstate/fast-agent",
+          "website": "https://fast-agent.ai",
+          "authors": [
+            "enquiries@fast-agent.ai"
+          ],
+          "license": "Apache 2.0",
+          "distribution": {
+            "uvx": {
+              "package": "fast-agent-acp==0.6.22",
+              "args": [
+                "-x"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/fast-agent.svg"
+    },
+    {
+      "id": "gemini",
+      "versions": [
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.21.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.21.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.22.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.22.2",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.22.3",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.22.3",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.22.5",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.22.5",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.23.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.23.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.24.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.24.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.24.5",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.24.5",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.25.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.25.2",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.26.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.26.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.27.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.27.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.27.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.27.2",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.27.3",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.27.3",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.28.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.28.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.28.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.28.1",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.28.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.28.2",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.1",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.2",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.3",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.3",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.4",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.4",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.5",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.5",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.6",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.6",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.29.7",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.29.7",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.30.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.30.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.30.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.30.1",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.31.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.31.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.32.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.32.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.32.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.32.1",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.33.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.33.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.33.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.33.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.33.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.33.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.34.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.34.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.35.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.35.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.35.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.35.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.35.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.35.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.35.3",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.35.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.36.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.36.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.37.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.37.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.37.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.37.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.37.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.37.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.38.0",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.38.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.38.1",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.38.1",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "gemini",
+          "name": "Gemini CLI",
+          "version": "0.38.2",
+          "description": "Google's official CLI for Gemini",
+          "repository": "https://github.com/google-gemini/gemini-cli",
+          "website": "https://geminicli.com",
+          "authors": [
+            "Google"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@google/gemini-cli@0.38.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/gemini.svg"
+    },
+    {
+      "id": "github-copilot",
+      "versions": [
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "0.0.400",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@0.0.400",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.410.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.410.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.411.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.411.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.413.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.413.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.417.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.417.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.418.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.418.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.421.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.421.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.423.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.423.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.425.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.425.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.428.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.428.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.429.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.429.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.430.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.430.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.431.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.431.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.432.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.432.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.434.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.434.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.435.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.435.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.436.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.436.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.437.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.437.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.438.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.438.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot",
+          "name": "GitHub Copilot",
+          "version": "1.439.0",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-language-server-release",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot-language-server@1.439.0",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/github-copilot.svg"
+    },
+    {
+      "id": "github-copilot-cli",
+      "versions": [
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "0.0.420",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "Microsoft"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@0.0.420",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "0.0.421",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@0.0.421",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "0.0.422",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@0.0.422",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "0.0.423",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@0.0.423",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.2",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.2",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.3",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.3",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.4",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.4",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.5",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.5",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.6",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.6",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.7",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.7",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.8",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.8",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.9",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.9",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.10",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.10",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.11",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.11",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.12",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.12",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.13",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.13",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.14",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.14",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.17",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.17",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.18",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.18",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.19",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.19",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.20",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.20",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.21",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.21",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.25",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.25",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.26",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.26",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.27",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.27",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.28",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.28",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.29",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.29",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.30",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.30",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.31",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.31",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.32",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.32",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.33",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.33",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "github-copilot-cli",
+          "name": "GitHub Copilot",
+          "version": "1.0.34",
+          "description": "GitHub's AI pair programmer",
+          "repository": "https://github.com/github/copilot-cli",
+          "website": "https://github.com/features/copilot/cli/",
+          "authors": [
+            "GitHub"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@github/copilot@1.0.34",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/github-copilot-cli.svg"
+    },
+    {
+      "id": "goose",
+      "versions": [
+        {
+          "id": "goose",
+          "name": "Goose",
+          "version": "1.16.1",
+          "description": "Block's open-source AI developer agent",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.16.1/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.16.1/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.16.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.16.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.16.1/goose-x86_64-pc-windows-gnu.zip",
+                "cmd": "./goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "Goose",
+          "version": "1.18.0",
+          "description": "Block's open-source AI developer agent",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.18.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.18.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.18.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.18.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.18.0/goose-x86_64-pc-windows-gnu.zip",
+                "cmd": "./goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.25.0",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.0/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.25.1",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.1/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.1/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.1/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.25.3",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.3/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.3/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.3/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.3/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.25.3/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.26.0",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.0/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.26.1",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.1/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.1/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.1/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.26.2",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.2/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.2/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.2/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.2/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.26.2/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.27.0",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.0/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.27.1",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.1/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.1/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.1/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.27.2",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.2/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.2/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.2/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.2/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.27.2/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "./goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.28.0",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "website": "https://block.github.io/goose/",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.28.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.28.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.28.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.28.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.28.0/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "./goose-package\\goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.29.0",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "website": "https://block.github.io/goose/",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.0/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "./goose-package\\goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.29.1",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "website": "https://block.github.io/goose/",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.1/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.1/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.29.1/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "./goose-package\\goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.30.0",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "website": "https://block.github.io/goose/",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.30.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.30.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.30.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.30.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.30.0/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "./goose-package\\goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.31.0",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "website": "https://block.github.io/goose/",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.0/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.0/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.0/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "./goose-package\\goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "goose",
+          "name": "goose",
+          "version": "1.31.1",
+          "description": "A local, extensible, open source AI agent that automates engineering tasks",
+          "repository": "https://github.com/block/goose",
+          "website": "https://block.github.io/goose/",
+          "authors": [
+            "Block"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.1/goose-aarch64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.1/goose-x86_64-apple-darwin.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
+                "cmd": "./goose",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/block/goose/releases/download/v1.31.1/goose-x86_64-pc-windows-msvc.zip",
+                "cmd": "./goose-package\\goose.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/goose.svg"
+    },
+    {
+      "id": "junie",
+      "versions": [
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "849.19.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@849.19.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.77.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@888.77.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.112.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie@888.112.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.117.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie@888.117.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.149.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie@888.149.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.156.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie@888.156.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.169.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie@888.169.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.173.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie@888.173.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.180.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.180/junie-release-888.180-macos-aarch64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.180/junie-release-888.180-macos-amd64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.180/junie-release-888.180-linux-aarch64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.180/junie-release-888.180-linux-amd64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.180/junie-release-888.180-windows-amd64.zip",
+                "cmd": "./junie/junie.exe",
+                "args": [
+                  "--acp=true"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.195.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.195/junie-release-888.195-macos-aarch64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.195/junie-release-888.195-macos-amd64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.195/junie-release-888.195-linux-aarch64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.195/junie-release-888.195-linux-amd64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.195/junie-release-888.195-windows-amd64.zip",
+                "cmd": "./junie/junie.exe",
+                "args": [
+                  "--acp=true"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "888.212.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "website": "https://junie.jetbrains.com",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.212/junie-release-888.212-macos-aarch64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.212/junie-release-888.212-macos-amd64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.212/junie-release-888.212-linux-aarch64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.212/junie-release-888.212-linux-amd64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/888.212/junie-release-888.212-windows-amd64.zip",
+                "cmd": "./junie/junie.exe",
+                "args": [
+                  "--acp=true"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "1321.57.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "website": "https://junie.jetbrains.com",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1321.57/junie-release-1321.57-macos-aarch64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1321.57/junie-release-1321.57-macos-amd64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1321.57/junie-release-1321.57-linux-aarch64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1321.57/junie-release-1321.57-linux-amd64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1321.57/junie-release-1321.57-windows-amd64.zip",
+                "cmd": "./junie/junie.exe",
+                "args": [
+                  "--acp=true"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "1362.39.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "website": "https://junie.jetbrains.com",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1362.39/junie-release-1362.39-macos-aarch64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1362.39/junie-release-1362.39-macos-amd64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1362.39/junie-release-1362.39-linux-aarch64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1362.39/junie-release-1362.39-linux-amd64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1362.39/junie-release-1362.39-windows-amd64.zip",
+                "cmd": "./junie/junie.exe",
+                "args": [
+                  "--acp=true"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "junie",
+          "name": "Junie",
+          "version": "1417.47.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/JetBrains/junie",
+          "website": "https://junie.jetbrains.com",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1417.47/junie-release-1417.47-macos-aarch64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1417.47/junie-release-1417.47-macos-amd64.zip",
+                "cmd": "./Applications/junie.app/Contents/MacOS/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1417.47/junie-release-1417.47-linux-aarch64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1417.47/junie-release-1417.47-linux-amd64.zip",
+                "cmd": "./junie-app/bin/junie",
+                "args": [
+                  "--acp=true"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/JetBrains/junie/releases/download/1417.47/junie-release-1417.47-windows-amd64.zip",
+                "cmd": "./junie/junie.exe",
+                "args": [
+                  "--acp=true"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/junie.svg"
+    },
+    {
+      "id": "junie-acp",
+      "versions": [
+        {
+          "id": "junie-acp",
+          "name": "Junie",
+          "version": "624.1.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@624.1.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie-acp",
+          "name": "Junie",
+          "version": "704.1.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@704.1.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie-acp",
+          "name": "Junie",
+          "version": "744.2.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@744.2.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie-acp",
+          "name": "Junie",
+          "version": "802.1.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@802.1.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie-acp",
+          "name": "Junie",
+          "version": "802.5.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@802.5.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie-acp",
+          "name": "Junie",
+          "version": "802.7.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@802.7.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        },
+        {
+          "id": "junie-acp",
+          "name": "Junie",
+          "version": "849.19.0",
+          "description": "AI Coding Agent by JetBrains",
+          "repository": "https://github.com/jetbrains-junie/junie",
+          "authors": [
+            "JetBrains"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@jetbrains/junie-cli@849.19.0",
+              "args": [
+                "--acp=true"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/junie-acp.svg"
+    },
+    {
+      "id": "kilo",
+      "versions": [
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.30",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.30/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.30/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.30/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.30/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.30/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.30",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.33",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.33/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.33/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.33/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.33/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.33/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.33",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.34",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.34/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.34/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.34/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.34/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.34/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.34",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.35",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.35/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.35/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.35/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.35/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.35/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.35",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.36",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.36/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.36/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.36/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.36/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.36/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.36",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.37",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.37/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.37/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.37/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.37/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.37/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.37",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.38",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.38/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.38/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.38/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.38/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.38/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.38",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.39",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.39/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.39/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.39/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.39/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.39/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.39",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.40",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.40/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.40/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.40/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.40/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.40/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.40",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.41",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.41/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.41/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.41/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.41/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.41/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.41",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.46",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.46/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.46/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.46/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.46/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.46/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.46",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.47",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.47/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.47/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.47/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.47/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.47/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.47",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.48",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.48/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.48/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.48/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.48/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.48/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.48",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.49",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.49/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.49/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.49/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.49/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.49/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.49",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.50",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.50/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.50/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.50/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.50/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.50/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.50",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.0.51",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.51/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.51/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.51/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.51/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.0.51/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.0.51",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.0",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.0/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.0/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.0/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.0/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.0/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.0",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.1",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.1/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.1/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.1/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.1/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.1/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.1",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.2",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.2/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.2/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.2/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.2/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.2/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.2",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.3",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.3/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.3/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.3/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.3/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.3/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.3",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.4",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.4/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.4/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.4/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.4/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.4/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.4",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.5",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.5/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.5/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.5/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.5/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.5/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.5",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.6",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.6/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.6/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.6/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.6/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.6/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.6",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.7",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.7/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.7/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.7/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.7/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.7/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.7",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.8",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.8/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.8/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.8/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.8/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.8/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.8",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.9",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.9/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.9/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.9/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.9/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.9/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.9",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.10",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.10/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.10/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.10/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.10/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.10/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.10",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.11",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.11/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.11/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.11/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.11/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.11/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.11",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.20",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.20/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.20/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.20/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.20/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.20/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.20",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.21",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.21/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.21/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.21/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.21/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.21/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.21",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.1.22",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.22/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.22/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.22/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.22/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.1.22/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.1.22",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.2.0",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.0/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.0/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.0/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.0/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.0/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.2.0",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.2.1",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.1/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.1/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.1/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.1/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.1/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.2.1",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.2.8",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.8/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.8/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.8/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.8/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.8/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.2.8",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.2.10",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.10/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.10/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.10/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.10/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.10/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.2.10",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.2.14",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.14/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.14/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.14/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.14/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.14/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.2.14",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.2.19",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.19/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.19/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.19/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.19/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.19/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.2.19",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "kilo",
+          "name": "Kilo",
+          "version": "7.2.20",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/Kilo-Org/kilocode",
+          "website": "https://kilo.ai/",
+          "authors": [
+            "Kilo Code"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.20/kilo-darwin-arm64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.20/kilo-darwin-x64.zip",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.20/kilo-linux-arm64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.20/kilo-linux-x64.tar.gz",
+                "cmd": "./kilo",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.2.20/kilo-windows-x64.zip",
+                "cmd": "./kilo.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            },
+            "npx": {
+              "package": "@kilocode/cli@7.2.20",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/kilo.svg"
+    },
+    {
+      "id": "kimi",
+      "versions": [
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "0.65.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.65/kimi-0.65-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "--acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.65/kimi-0.65-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "--acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.65/kimi-0.65-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "--acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.65/kimi-0.65-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "--acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "0.67.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.67/kimi-0.67-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "--acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.67/kimi-0.67-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "--acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.67/kimi-0.67-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "--acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/0.67/kimi-0.67-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "--acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.6.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.6/kimi-1.6-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.6/kimi-1.6-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.6/kimi-1.6-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.6/kimi-1.6-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.9.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.9.0/kimi-1.9.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.11.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.11.0/kimi-1.11.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.11.0/kimi-1.11.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.11.0/kimi-1.11.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.11.0/kimi-1.11.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.12.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.12.0/kimi-1.12.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.12.0/kimi-1.12.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.12.0/kimi-1.12.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.12.0/kimi-1.12.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.13.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.13.0/kimi-1.13.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.13.0/kimi-1.13.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.13.0/kimi-1.13.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.13.0/kimi-1.13.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.14.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.14.0/kimi-1.14.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.14.0/kimi-1.14.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.14.0/kimi-1.14.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.14.0/kimi-1.14.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.16.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.16.0/kimi-1.16.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.16.0/kimi-1.16.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.16.0/kimi-1.16.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.16.0/kimi-1.16.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.17.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.17.0/kimi-1.17.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.17.0/kimi-1.17.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.17.0/kimi-1.17.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.17.0/kimi-1.17.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.18.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.18.0/kimi-1.18.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.18.0/kimi-1.18.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.18.0/kimi-1.18.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.18.0/kimi-1.18.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.20.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.20.0/kimi-1.20.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.20.0/kimi-1.20.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.20.0/kimi-1.20.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.20.0/kimi-1.20.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.21.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.21.0/kimi-1.21.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.21.0/kimi-1.21.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.21.0/kimi-1.21.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.21.0/kimi-1.21.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.22.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.22.0/kimi-1.22.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.22.0/kimi-1.22.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.22.0/kimi-1.22.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.22.0/kimi-1.22.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.23.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.23.0/kimi-1.23.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.23.0/kimi-1.23.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.23.0/kimi-1.23.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.23.0/kimi-1.23.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.24.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.24.0/kimi-1.24.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.24.0/kimi-1.24.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.24.0/kimi-1.24.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.24.0/kimi-1.24.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.25.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.25.0/kimi-1.25.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.25.0/kimi-1.25.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.25.0/kimi-1.25.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.25.0/kimi-1.25.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.26.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.26.0/kimi-1.26.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.26.0/kimi-1.26.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.26.0/kimi-1.26.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.26.0/kimi-1.26.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.27.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.27.0/kimi-1.27.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.27.0/kimi-1.27.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.27.0/kimi-1.27.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.27.0/kimi-1.27.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.28.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.28.0/kimi-1.28.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.28.0/kimi-1.28.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.28.0/kimi-1.28.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.28.0/kimi-1.28.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.30.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.30.0/kimi-1.30.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.30.0/kimi-1.30.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.30.0/kimi-1.30.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.30.0/kimi-1.30.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.32.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.32.0/kimi-1.32.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.32.0/kimi-1.32.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.32.0/kimi-1.32.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.32.0/kimi-1.32.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.33.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.33.0/kimi-1.33.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.33.0/kimi-1.33.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.33.0/kimi-1.33.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.33.0/kimi-1.33.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.34.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.34.0/kimi-1.34.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.34.0/kimi-1.34.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.34.0/kimi-1.34.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.34.0/kimi-1.34.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.35.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.35.0/kimi-1.35.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.35.0/kimi-1.35.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.35.0/kimi-1.35.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.35.0/kimi-1.35.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.36.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.36.0/kimi-1.36.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.36.0/kimi-1.36.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.36.0/kimi-1.36.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.36.0/kimi-1.36.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "kimi",
+          "name": "Kimi CLI",
+          "version": "1.37.0",
+          "description": "Moonshot AI's coding assistant",
+          "repository": "https://github.com/MoonshotAI/kimi-cli",
+          "website": "https://moonshotai.github.io/kimi-cli/",
+          "authors": [
+            "Moonshot AI"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.37.0/kimi-1.37.0-aarch64-apple-darwin.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.37.0/kimi-1.37.0-aarch64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.37.0/kimi-1.37.0-x86_64-unknown-linux-gnu.tar.gz",
+                "cmd": "./kimi",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.37.0/kimi-1.37.0-x86_64-pc-windows-msvc.zip",
+                "cmd": "./kimi.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/kimi.svg"
+    },
+    {
+      "id": "minion-code",
+      "versions": [
+        {
+          "id": "minion-code",
+          "name": "Minion Code",
+          "version": "0.1.39",
+          "description": "An enhanced AI code assistant built on the Minion framework with rich development tools",
+          "repository": "https://github.com/femto/minion-code",
+          "authors": [
+            "femto"
+          ],
+          "license": "AGPL-3.0",
+          "distribution": {
+            "uvx": {
+              "package": "minion-code@0.1.39",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "minion-code",
+          "name": "Minion Code",
+          "version": "0.1.42",
+          "description": "An enhanced AI code assistant built on the Minion framework with rich development tools",
+          "repository": "https://github.com/femto/minion-code",
+          "authors": [
+            "femto"
+          ],
+          "license": "AGPL-3.0",
+          "distribution": {
+            "uvx": {
+              "package": "minion-code@0.1.42",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "minion-code",
+          "name": "Minion Code",
+          "version": "0.1.43",
+          "description": "An enhanced AI code assistant built on the Minion framework with rich development tools",
+          "repository": "https://github.com/femto/minion-code",
+          "authors": [
+            "femto"
+          ],
+          "license": "AGPL-3.0",
+          "distribution": {
+            "uvx": {
+              "package": "minion-code@0.1.43",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "minion-code",
+          "name": "Minion Code",
+          "version": "0.1.44",
+          "description": "An enhanced AI code assistant built on the Minion framework with rich development tools",
+          "repository": "https://github.com/femto/minion-code",
+          "authors": [
+            "femto"
+          ],
+          "license": "AGPL-3.0",
+          "distribution": {
+            "uvx": {
+              "package": "minion-code@0.1.44",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/minion-code.svg"
+    },
+    {
+      "id": "mistral-vibe",
+      "versions": [
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "1.1.3",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.1.3/vibe-acp-darwin-aarch64-1.1.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.1.3/vibe-acp-darwin-x86_64-1.1.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.1.3/vibe-acp-linux-aarch64-1.1.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.1.3/vibe-acp-linux-x86_64-1.1.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.1.3/vibe-acp-windows-aarch64-1.1.3.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.1.3/vibe-acp-windows-x86_64-1.1.3.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "1.3.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.0/vibe-acp-darwin-aarch64-1.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.0/vibe-acp-darwin-x86_64-1.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.0/vibe-acp-linux-aarch64-1.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.0/vibe-acp-linux-x86_64-1.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.0/vibe-acp-windows-aarch64-1.3.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.0/vibe-acp-windows-x86_64-1.3.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "1.3.3",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.3/vibe-acp-darwin-aarch64-1.3.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.3/vibe-acp-darwin-x86_64-1.3.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.3/vibe-acp-linux-aarch64-1.3.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.3/vibe-acp-linux-x86_64-1.3.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.3/vibe-acp-windows-aarch64-1.3.3.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.3/vibe-acp-windows-x86_64-1.3.3.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "1.3.4",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.4/vibe-acp-darwin-aarch64-1.3.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.4/vibe-acp-darwin-x86_64-1.3.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.4/vibe-acp-linux-aarch64-1.3.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.4/vibe-acp-linux-x86_64-1.3.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.4/vibe-acp-windows-aarch64-1.3.4.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.4/vibe-acp-windows-x86_64-1.3.4.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "1.3.5",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.5/vibe-acp-darwin-aarch64-1.3.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.5/vibe-acp-darwin-x86_64-1.3.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.5/vibe-acp-linux-aarch64-1.3.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.5/vibe-acp-linux-x86_64-1.3.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.5/vibe-acp-windows-aarch64-1.3.5.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v1.3.5/vibe-acp-windows-x86_64-1.3.5.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.0.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.0/vibe-acp-darwin-aarch64-2.0.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.0/vibe-acp-darwin-x86_64-2.0.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.0/vibe-acp-linux-aarch64-2.0.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.0/vibe-acp-linux-x86_64-2.0.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.0/vibe-acp-windows-aarch64-2.0.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.0/vibe-acp-windows-x86_64-2.0.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.0.1",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.1/vibe-acp-darwin-aarch64-2.0.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.1/vibe-acp-darwin-x86_64-2.0.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.1/vibe-acp-linux-aarch64-2.0.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.1/vibe-acp-linux-x86_64-2.0.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.1/vibe-acp-windows-aarch64-2.0.1.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.1/vibe-acp-windows-x86_64-2.0.1.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.0.2",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.2/vibe-acp-darwin-aarch64-2.0.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.2/vibe-acp-darwin-x86_64-2.0.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.2/vibe-acp-linux-aarch64-2.0.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.2/vibe-acp-linux-x86_64-2.0.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.2/vibe-acp-windows-aarch64-2.0.2.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.0.2/vibe-acp-windows-x86_64-2.0.2.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.1.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.1.0/vibe-acp-darwin-aarch64-2.1.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.1.0/vibe-acp-darwin-x86_64-2.1.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.1.0/vibe-acp-linux-aarch64-2.1.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.1.0/vibe-acp-linux-x86_64-2.1.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.1.0/vibe-acp-windows-aarch64-2.1.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.1.0/vibe-acp-windows-x86_64-2.1.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.2.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.0/vibe-acp-darwin-aarch64-2.2.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.0/vibe-acp-darwin-x86_64-2.2.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.0/vibe-acp-linux-aarch64-2.2.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.0/vibe-acp-linux-x86_64-2.2.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.0/vibe-acp-windows-aarch64-2.2.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.0/vibe-acp-windows-x86_64-2.2.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.2.1",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.1/vibe-acp-darwin-aarch64-2.2.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.1/vibe-acp-darwin-x86_64-2.2.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.1/vibe-acp-linux-aarch64-2.2.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.1/vibe-acp-linux-x86_64-2.2.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.1/vibe-acp-windows-aarch64-2.2.1.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.2.1/vibe-acp-windows-x86_64-2.2.1.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.3.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.3.0/vibe-acp-darwin-aarch64-2.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.3.0/vibe-acp-darwin-x86_64-2.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.3.0/vibe-acp-linux-aarch64-2.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.3.0/vibe-acp-linux-x86_64-2.3.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.3.0/vibe-acp-windows-aarch64-2.3.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.3.0/vibe-acp-windows-x86_64-2.3.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.4.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.0/vibe-acp-darwin-aarch64-2.4.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.0/vibe-acp-darwin-x86_64-2.4.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.0/vibe-acp-linux-aarch64-2.4.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.0/vibe-acp-linux-x86_64-2.4.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.0/vibe-acp-windows-aarch64-2.4.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.0/vibe-acp-windows-x86_64-2.4.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.4.1",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.1/vibe-acp-darwin-aarch64-2.4.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.1/vibe-acp-darwin-x86_64-2.4.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.1/vibe-acp-linux-aarch64-2.4.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.1/vibe-acp-linux-x86_64-2.4.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.1/vibe-acp-windows-aarch64-2.4.1.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.1/vibe-acp-windows-x86_64-2.4.1.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.4.2",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.2/vibe-acp-darwin-aarch64-2.4.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.2/vibe-acp-darwin-x86_64-2.4.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.2/vibe-acp-linux-aarch64-2.4.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.2/vibe-acp-linux-x86_64-2.4.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.2/vibe-acp-windows-aarch64-2.4.2.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.4.2/vibe-acp-windows-x86_64-2.4.2.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.5.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.5.0/vibe-acp-darwin-aarch64-2.5.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.5.0/vibe-acp-darwin-x86_64-2.5.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.5.0/vibe-acp-linux-aarch64-2.5.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.5.0/vibe-acp-linux-x86_64-2.5.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.5.0/vibe-acp-windows-aarch64-2.5.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.5.0/vibe-acp-windows-x86_64-2.5.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.6.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.0/vibe-acp-darwin-aarch64-2.6.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.0/vibe-acp-darwin-x86_64-2.6.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.0/vibe-acp-linux-aarch64-2.6.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.0/vibe-acp-linux-x86_64-2.6.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.0/vibe-acp-windows-aarch64-2.6.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.0/vibe-acp-windows-x86_64-2.6.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.6.1",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.1/vibe-acp-darwin-aarch64-2.6.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.1/vibe-acp-darwin-x86_64-2.6.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.1/vibe-acp-linux-aarch64-2.6.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.1/vibe-acp-linux-x86_64-2.6.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.1/vibe-acp-windows-aarch64-2.6.1.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.1/vibe-acp-windows-x86_64-2.6.1.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.6.2",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.2/vibe-acp-darwin-aarch64-2.6.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.2/vibe-acp-darwin-x86_64-2.6.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.2/vibe-acp-linux-aarch64-2.6.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.2/vibe-acp-linux-x86_64-2.6.2.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.2/vibe-acp-windows-aarch64-2.6.2.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.6.2/vibe-acp-windows-x86_64-2.6.2.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.7.0",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.0/vibe-acp-darwin-aarch64-2.7.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.0/vibe-acp-darwin-x86_64-2.7.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.0/vibe-acp-linux-aarch64-2.7.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.0/vibe-acp-linux-x86_64-2.7.0.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.0/vibe-acp-windows-aarch64-2.7.0.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.0/vibe-acp-windows-x86_64-2.7.0.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.7.3",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.3/vibe-acp-darwin-aarch64-2.7.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.3/vibe-acp-darwin-x86_64-2.7.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.3/vibe-acp-linux-aarch64-2.7.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.3/vibe-acp-linux-x86_64-2.7.3.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.3/vibe-acp-windows-aarch64-2.7.3.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.3/vibe-acp-windows-x86_64-2.7.3.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.7.4",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.4/vibe-acp-darwin-aarch64-2.7.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.4/vibe-acp-darwin-x86_64-2.7.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.4/vibe-acp-linux-aarch64-2.7.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.4/vibe-acp-linux-x86_64-2.7.4.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.4/vibe-acp-windows-aarch64-2.7.4.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.4/vibe-acp-windows-x86_64-2.7.4.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.7.5",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.5/vibe-acp-darwin-aarch64-2.7.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.5/vibe-acp-darwin-x86_64-2.7.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.5/vibe-acp-linux-aarch64-2.7.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.5/vibe-acp-linux-x86_64-2.7.5.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.5/vibe-acp-windows-aarch64-2.7.5.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.5/vibe-acp-windows-x86_64-2.7.5.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.7.6",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.6/vibe-acp-darwin-aarch64-2.7.6.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.6/vibe-acp-darwin-x86_64-2.7.6.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.6/vibe-acp-linux-aarch64-2.7.6.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.6/vibe-acp-linux-x86_64-2.7.6.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.6/vibe-acp-windows-aarch64-2.7.6.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.7.6/vibe-acp-windows-x86_64-2.7.6.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        },
+        {
+          "id": "mistral-vibe",
+          "name": "Mistral Vibe",
+          "version": "2.8.1",
+          "description": "Mistral's open-source coding assistant",
+          "repository": "https://github.com/mistralai/mistral-vibe",
+          "website": "https://mistral.ai/products/vibe",
+          "authors": [
+            "Mistral AI"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.8.1/vibe-acp-darwin-aarch64-2.8.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.8.1/vibe-acp-darwin-x86_64-2.8.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.8.1/vibe-acp-linux-aarch64-2.8.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.8.1/vibe-acp-linux-x86_64-2.8.1.zip",
+                "cmd": "./vibe-acp"
+              },
+              "windows-aarch64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.8.1/vibe-acp-windows-aarch64-2.8.1.zip",
+                "cmd": "./vibe-acp.exe"
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.8.1/vibe-acp-windows-x86_64-2.8.1.zip",
+                "cmd": "./vibe-acp.exe"
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/mistral-vibe.svg"
+    },
+    {
+      "id": "nova",
+      "versions": [
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.66",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.66",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.67",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.67",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.68",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.68",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.69",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.69",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.70",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.70",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.71",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.71",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.72",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.72",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.74",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.74",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.75",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.75",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.76",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.76",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.78",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.78",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.79",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.79",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.80",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.80",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.81",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.81",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.82",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.82",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.83",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.83",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.84",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.84",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.85",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.85",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.86",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.86",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.87",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.87",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.88",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.88",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.89",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.89",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.90",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.90",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.91",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.91",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.93",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.93",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.94",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.94",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.95",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.95",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.96",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.96",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.97",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.97",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.98",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.98",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.99",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.99",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "nova",
+          "name": "Nova",
+          "version": "1.0.100",
+          "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
+          "repository": "https://github.com/Compass-Agentic-Platform/nova",
+          "website": "https://www.compassap.ai/portfolio/nova.html",
+          "authors": [
+            "Compass AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@compass-ai/nova@1.0.100",
+              "args": [
+                "acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/nova.svg"
+    },
+    {
+      "id": "opencode",
+      "versions": [
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.0.164",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.164/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.164/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.164/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.164/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.164/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.0.193",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.193/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.193/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.193/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.193/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.193/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.0.203",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.203/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.203/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.203/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.203/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.0.203/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.2",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.2/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.2/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.2/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.2/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.2/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.6",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.6/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.6/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.6/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.6/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.6/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.21",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.21/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.21/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.21/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.21/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.21/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.23",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.23/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.23/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.23/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.23/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.23/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.26",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.26/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.26/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.26/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.26/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.26/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.34",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.34/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.34/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.34/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.34/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.34/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.36",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.36/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.36/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.36/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.36/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.36/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.39",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.39/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.39/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.39/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.39/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.39/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.42",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.42/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.42/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.42/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.42/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.42/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.47",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.47/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.47/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.47/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.47/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.47/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.48",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.48/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.48/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.48/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.48/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.48/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.51",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.51/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.51/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.51/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.51/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.51/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.52",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.52/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.52/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.52/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.52/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.52/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.53",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.53/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.53/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.53/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.53/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.53/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.56",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.56/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.56/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.56/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.56/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.56/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.57",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.57/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.57/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.57/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.57/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.57/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.59",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/sst/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.59/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.59/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.59/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.59/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/sst/opencode/releases/download/v1.1.59/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.60",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.60/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.60/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.60/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.60/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.60/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.61",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.61/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.61/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.61/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.61/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.61/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.63",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.63/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.63/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.63/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.63/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.63/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.64",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.64/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.64/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.64/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.64/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.64/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.1.65",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.1.65/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.5",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.5/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.6",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.6/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.6/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.6/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.6/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.6/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.8",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.8/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.8/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.8/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.8/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.8/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.9",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.9/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.9/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.9/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.9/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.9/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.10",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.10/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.10/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.10/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.10/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.10/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.11",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.11/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.11/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.11/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.11/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.11/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.13",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.13/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.13/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.13/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.13/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.13/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.14",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.14/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.14/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.14/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.14/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.14/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.15",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.15/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.15/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.15/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.15/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.15/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.16",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.16/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.16/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.16/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.16/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.16/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.17",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.17/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.17/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.17/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.17/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.17/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.18",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.18/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.18/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.18/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.18/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.18/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.19",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.19/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.19/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.19/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.19/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.19/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.20",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.20/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.20/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.20/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.20/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.20/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.21",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.21/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.21/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.21/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.21/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.21/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.22",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.22/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.22/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.22/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.22/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.22/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.23",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.23/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.23/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.23/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.23/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.23/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.24",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.24/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.24/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.24/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.24/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.24/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.25",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.25/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.25/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.25/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.25/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.25/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.26",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.26/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.26/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.26/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.26/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.26/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.2.27",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.27/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.27/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.27/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.27/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.2.27/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.0",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.0/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.0/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.0/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.0/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.0/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.1",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.1/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.1/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.1/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.1/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.1/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.2",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.2/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.2/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.2/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.2/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.2/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.3",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.3/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.3/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.3/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.3/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.3/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.4",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.4/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.4/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.4/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.4/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.4/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.5",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.5/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.5/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.5/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.5/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.5/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.6",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.6/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.6/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.6/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.6/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.6/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.7",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.7/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.7/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.7/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.7/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.7/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.8",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.8/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.8/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.8/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.8/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.8/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.9",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.9/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.9/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.9/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.9/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.9/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.13",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.13/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.13/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.13/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.13/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.13/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.14",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.14/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.14/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.14/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.14/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.14/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.15",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.15/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.15/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.15/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.15/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.15/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.16",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.16/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.16/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.16/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.16/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.16/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.3.17",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.17/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.17/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.17/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.17/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.3.17/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.0",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.0/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.0/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.0/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.0/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.0/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.1",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.1/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.1/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.1/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.1/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.1/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.3",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.3/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.3/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.3/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.3/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.3/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.4",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.4/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.4/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.4/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.4/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.4/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.5",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.5/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.5/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.5/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.5/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.5/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.6",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.6/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.6/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.6/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.6/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.6/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.7",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.7/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.7/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.7/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.7/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.7/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.8",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.8/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.8/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.8/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.8/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.8/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.9",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.9/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.9/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.9/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.9/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.9/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.10",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.10/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.10/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.10/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.10/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.10/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.4.11",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.11/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.11/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.11/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.11/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.4.11/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.14.17",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.17/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.17/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.17/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.17/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.17/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.14.18",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.18/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.18/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.18/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.18/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.18/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.14.19",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "opencode",
+          "name": "OpenCode",
+          "version": "1.14.20",
+          "description": "The open source coding agent",
+          "repository": "https://github.com/anomalyco/opencode",
+          "website": "https://opencode.ai",
+          "authors": [
+            "Anomaly"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-darwin-arm64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-darwin-x64.zip",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-linux-arm64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-linux-x64.tar.gz",
+                "cmd": "./opencode",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-windows-x64.zip",
+                "cmd": "./opencode.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/opencode.svg"
+    },
+    {
+      "id": "pi-acp",
+      "versions": [
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.16",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.16"
+            }
+          }
+        },
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.20",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.20"
+            }
+          }
+        },
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.21",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.21"
+            }
+          }
+        },
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.22",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.22"
+            }
+          }
+        },
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.23",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.23"
+            }
+          }
+        },
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.24",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.24"
+            }
+          }
+        },
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.25",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.25"
+            }
+          }
+        },
+        {
+          "id": "pi-acp",
+          "name": "pi ACP",
+          "version": "0.0.26",
+          "description": "ACP adapter for pi coding agent",
+          "repository": "https://github.com/svkozak/pi-acp",
+          "authors": [
+            "Sergii Kozak <svkozak@gmail.com>"
+          ],
+          "license": "MIT",
+          "distribution": {
+            "npx": {
+              "package": "pi-acp@0.0.26"
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/pi-acp.svg"
+    },
+    {
+      "id": "qoder",
+      "versions": [
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.24",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.24",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.26",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.26",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.27",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.27",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.28",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.28",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.29",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.29",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.30",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.30",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.31",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.31",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.32",
+          "description": "AI coding assistant with agentic capabilities",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.32",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.33",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.33",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.34",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.34",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.35",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.35",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.36",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.36",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.37",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.37",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.38",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.38",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.39",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.39",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.42",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.42",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.43",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.43",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.44",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.44",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.45",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.45",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.46",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.46",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qoder",
+          "name": "Qoder CLI",
+          "version": "0.1.47",
+          "description": "AI coding assistant with agentic capabilities",
+          "website": "https://qoder.com",
+          "authors": [
+            "Qoder AI"
+          ],
+          "license": "proprietary",
+          "distribution": {
+            "npx": {
+              "package": "@qoder-ai/qodercli@0.1.47",
+              "args": [
+                "--acp"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/qoder.svg"
+    },
+    {
+      "id": "qwen-code",
+      "versions": [
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.5.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.5.1",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.5.2",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.5.2",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.6.0",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.6.0",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.6.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.6.1",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.7.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.7.1",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.7.2",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.7.2",
+              "args": [
+                "--experimental-acp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.8.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.8.1",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.8.2",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.8.2",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.9.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.9.1",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.10.0",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.10.0",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.10.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.10.1",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.10.2",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.10.2",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.10.3",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.10.3",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.10.5",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.10.5",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.10.6",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.10.6",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.11.0",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.11.0",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.11.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.11.1",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.12.0",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.12.0",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.12.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.12.1",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.12.2",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.12.2",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.12.3",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.12.3",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.12.4",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.12.4",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.12.5",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.12.5",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.12.6",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.12.6",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.13.0",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.13.0",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.13.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.13.1",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.13.2",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.13.2",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.14.0",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.14.0",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.14.1",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.14.1",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.14.2",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.14.2",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.14.4",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.14.4",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.14.5",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.14.5",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        },
+        {
+          "id": "qwen-code",
+          "name": "Qwen Code",
+          "version": "0.15.0",
+          "description": "Alibaba's Qwen coding assistant",
+          "repository": "https://github.com/QwenLM/qwen-code",
+          "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
+          "authors": [
+            "Alibaba Qwen Team"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "npx": {
+              "package": "@qwen-code/qwen-code@0.15.0",
+              "args": [
+                "--acp",
+                "--experimental-skills"
+              ]
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/qwen-code.svg"
+    },
+    {
+      "id": "stakpak",
+      "versions": [
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.3",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security.",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.3/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.3/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.3/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.3/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.3/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.16",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.16/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.16/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.16/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.16/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.16/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.34",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.34/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.34/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.34/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.34/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.34/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.38",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.38/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.38/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.38/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.38/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.38/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.40",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.40/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.40/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.40/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.40/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.40/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.41",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.41/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.41/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.41/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.41/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.41/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.42",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.42/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.42/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.42/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.42/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.42/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.43",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.43/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.43/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.43/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.43/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.43/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.44",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.44/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.44/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.44/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.44/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.44/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.45",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.45/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.45/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.45/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.45/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.45/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.47",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.47/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.47/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.47/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.47/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.47/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.48",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.48/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.48/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.48/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.48/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.48/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.53",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.53/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.53/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.53/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.53/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.53/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.54",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.54/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.54/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.54/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.54/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.54/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.56",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.56/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.56/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.56/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.56/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.56/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.57",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.57/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.57/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.57/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.57/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.57/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.58",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.58/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.58/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.58/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.58/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.58/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.59",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.59/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.59/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.59/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.59/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.59/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.60",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.60/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.60/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.60/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.60/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.60/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.61",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.61/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.61/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.61/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.61/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.61/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.62",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.62/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.64",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.64/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.65",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.65/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.65/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.65/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.65/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.65/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.66",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.66/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.66/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.66/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.66/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.66/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.67",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.67/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.67/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.67/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.67/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.67/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.68",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.68/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.68/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.68/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.68/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.68/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.69",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "website": "https://stakpak.dev",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.69/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.69/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.69/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.69/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.69/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.70",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "website": "https://stakpak.dev",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.70/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.70/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.70/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.70/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.70/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.71",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "website": "https://stakpak.dev",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.71/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.71/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.71/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.71/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.71/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.72",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "website": "https://stakpak.dev",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.72/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.72/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.72/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.72/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.72/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.73",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "website": "https://stakpak.dev",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.73/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.73/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.73/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.73/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.73/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "stakpak",
+          "name": "Stakpak",
+          "version": "0.3.74",
+          "description": "Open-source DevOps agent in Rust with enterprise-grade security",
+          "repository": "https://github.com/stakpak/agent",
+          "website": "https://stakpak.dev",
+          "authors": [
+            "Stakpak Team <contact@stakpak.dev>"
+          ],
+          "license": "Apache-2.0",
+          "distribution": {
+            "binary": {
+              "darwin-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.74/stakpak-darwin-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "darwin-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.74/stakpak-darwin-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-aarch64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.74/stakpak-linux-aarch64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "linux-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.74/stakpak-linux-x86_64.tar.gz",
+                "cmd": "./stakpak",
+                "args": [
+                  "acp"
+                ]
+              },
+              "windows-x86_64": {
+                "archive": "https://github.com/stakpak/agent/releases/download/v0.3.74/stakpak-windows-x86_64.zip",
+                "cmd": "./stakpak.exe",
+                "args": [
+                  "acp"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "icon": "https://cdn.agentclientprotocol.com/registry/v1/latest/stakpak.svg"
+    }
+  ]
+}

--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -63,8 +63,18 @@ jobs:
         with:
           node-version: "lts/*"
 
+      - name: Prepare previous registry archive
+        run: |
+          mkdir -p .tmp
+          curl -fsSLo .tmp/previous-registry-archive.json \
+            https://cdn.agentclientprotocol.com/registry/v1/latest/registry-archive.json \
+            || cp .github/workflows/bootstrap/registry-archive.seed.json \
+              .tmp/previous-registry-archive.json
+
       - name: Validate and build
-        run: uv run --with jsonschema .github/workflows/build_registry.py
+        run: >-
+          uv run --with jsonschema .github/workflows/build_registry.py
+          --previous-archive .tmp/previous-registry-archive.json
 
       - name: List agents for auth matrix
         id: list-agents
@@ -221,6 +231,8 @@ jobs:
             --title "Registry $VERSION" \
             --notes "$RELEASE_NOTES" \
             dist/registry.json \
+            dist/registry-archive.json \
             dist/agent.schema.json \
             dist/registry.schema.json \
+            dist/registry-archive.schema.json \
             dist/*.svg

--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -12,6 +12,12 @@ import urllib.request
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from registry_archive import (
+    build_registry_archive,
+    load_registry_archive,
+    validate_registry_archive,
+    validate_registry_archive_sync,
+)
 from registry_utils import (
     extract_npm_package_name,
     extract_npm_package_version,
@@ -43,6 +49,7 @@ REJECTED_ARCHIVE_EXTENSIONS = (".dmg", ".pkg", ".deb", ".rpm", ".msi", ".appimag
 
 # Can be overridden via environment variable
 DEFAULT_BASE_URL = "https://cdn.agentclientprotocol.com/registry/v1/latest"
+DEFAULT_PREVIOUS_ARCHIVE = ".github/workflows/bootstrap/registry-archive.seed.json"
 
 # Icon requirements
 PREFERRED_ICON_SIZE = 16
@@ -330,17 +337,24 @@ def get_base_url():
     return os.environ.get("REGISTRY_BASE_URL", DEFAULT_BASE_URL)
 
 
-def load_schema(registry_dir: Path) -> dict | None:
-    """Load agent.schema.json if available."""
-    schema_path = registry_dir / "agent.schema.json"
-    if not schema_path.exists():
+def load_json_file(path: Path) -> dict | None:
+    """Load a JSON object from a file path."""
+    if not path.exists():
         return None
     try:
-        with open(schema_path) as f:
+        with open(path) as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError) as e:
-        print(f"Warning: Could not load agent.schema.json: {e}")
+        print(f"Warning: Could not load {path.name}: {e}")
         return None
+
+
+def load_schema(registry_dir: Path, filename: str = "agent.schema.json") -> dict | None:
+    """Load a schema file if available."""
+    schema_path = registry_dir / filename
+    if not schema_path.exists():
+        return None
+    return load_json_file(schema_path)
 
 
 def validate_against_schema(agent: dict, schema: dict) -> list[str]:
@@ -517,17 +531,19 @@ def process_entry(
     return entry, []
 
 
-def build_registry(dry_run: bool = False):
+def build_registry(dry_run: bool = False, previous_archive_path: str | None = None):
     """Build registry.json from agent directories.
 
     Args:
         dry_run: If True, validate and report what would be built without writing to dist/.
+        previous_archive_path: Path to previous registry-archive.json used for incremental updates.
     """
     registry_dir = Path(__file__).parent.parent.parent
     base_url = get_base_url()
     agents = []
     seen_ids = {}
     has_errors = False
+    previous_archive = None
 
     # Load schema for validation
     schema = load_schema(registry_dir)
@@ -594,6 +610,32 @@ def build_registry(dry_run: bool = False):
     jetbrains_agents = [
         patch_agent_for_jetbrains(a) for a in agents if a["id"] not in JETBRAINS_EXCLUDE_IDS
     ]
+    if previous_archive_path is None:
+        default_previous_archive_path = registry_dir / DEFAULT_PREVIOUS_ARCHIVE
+        if default_previous_archive_path.exists():
+            previous_archive_path = str(default_previous_archive_path)
+    if previous_archive_path is not None:
+        previous_archive_file = Path(previous_archive_path)
+        if not previous_archive_file.exists():
+            print(f"Error: Previous registry archive not found: {previous_archive_file}")
+            sys.exit(1)
+        previous_archive = load_registry_archive(previous_archive_file)
+
+    registry_archive = build_registry_archive(agents, previous_archive)
+    archive_errors = validate_registry_archive(registry_archive)
+    if archive_errors:
+        print("Error: Generated registry-archive.json is invalid:")
+        for error in archive_errors:
+            print(f"  - {error}")
+        sys.exit(1)
+    archive_sync_errors = validate_registry_archive_sync(agents, registry_archive)
+    if archive_sync_errors:
+        print("Error: registry-archive.json does not match the current registry snapshot:")
+        for error in archive_sync_errors:
+            print(f"  - {error}")
+        sys.exit(1)
+    archive_agent_count = len(registry_archive["agents"])
+    archive_version_count = sum(len(agent["versions"]) for agent in registry_archive["agents"])
 
     if dry_run:
         print(f"\nDry run: validated {len(agents)} agents successfully")
@@ -604,6 +646,10 @@ def build_registry(dry_run: bool = False):
         print(
             f"  registry-for-jetbrains.json would contain "
             f"{len(jetbrains_agents)} agents (excluded: {', '.join(sorted(JETBRAINS_EXCLUDE_IDS))})"
+        )
+        print(
+            f"  registry-archive.json would contain {archive_agent_count} agents and "
+            f"{archive_version_count} versions"
         )
         return
 
@@ -628,6 +674,12 @@ def build_registry(dry_run: bool = False):
         json.dump(jetbrains_registry, f, indent=2)
         f.write("\n")
 
+    # Write registry-archive.json
+    archive_output_path = dist_dir / "registry-archive.json"
+    with open(archive_output_path, "w") as f:
+        json.dump(registry_archive, f, indent=2)
+        f.write("\n")
+
     # Copy icons to dist
     for entry in agents:
         entry_id = entry["id"]
@@ -637,7 +689,11 @@ def build_registry(dry_run: bool = False):
             icon_dst.write_bytes(icon_src.read_bytes())
 
     # Copy schema files to dist
-    for schema_file in ("agent.schema.json", "registry.schema.json"):
+    for schema_file in (
+        "agent.schema.json",
+        "registry.schema.json",
+        "registry-archive.schema.json",
+    ):
         schema_src = registry_dir / schema_file
         if schema_src.exists():
             schema_dst = dist_dir / schema_file
@@ -652,6 +708,9 @@ def build_registry(dry_run: bool = False):
         f"  registry-for-jetbrains.json: {len(jetbrains_agents)} agents"
         f" (excluded: {', '.join(sorted(JETBRAINS_EXCLUDE_IDS))})"
     )
+    print(
+        f"  registry-archive.json: {archive_agent_count} agents, {archive_version_count} versions"
+    )
 
 
 if __name__ == "__main__":
@@ -661,5 +720,9 @@ if __name__ == "__main__":
         action="store_true",
         help="Validate all agents without writing to dist/",
     )
+    parser.add_argument(
+        "--previous-archive",
+        help="Path to previous registry-archive.json for incremental archive updates",
+    )
     args = parser.parse_args()
-    build_registry(dry_run=args.dry_run)
+    build_registry(dry_run=args.dry_run, previous_archive_path=args.previous_archive)

--- a/.github/workflows/registry_archive.py
+++ b/.github/workflows/registry_archive.py
@@ -1,0 +1,240 @@
+"""Helpers for building and validating registry-archive.json."""
+
+import copy
+import json
+from pathlib import Path
+
+from registry_utils import normalize_version
+
+ARCHIVE_VERSION = "1.0.0"
+
+
+def version_sort_key(version: str) -> tuple[int, ...]:
+    """Return a sortable key for numeric dotted versions."""
+    normalized = normalize_version(version)
+    parts = normalized.split(".")
+    if not all(part.isdigit() for part in parts):
+        raise ValueError(f"Unsupported version format: {version}")
+    return tuple(int(part) for part in parts)
+
+
+def strip_icon(agent: dict) -> dict:
+    """Return a historical entry without the shared icon."""
+    return {key: value for key, value in agent.items() if key != "icon"}
+
+
+def _merge_agent_into_archive(archive_by_id: dict[str, dict], agent: dict) -> None:
+    """Merge a single agent entry into the archive index."""
+    if not isinstance(agent, dict):
+        raise ValueError("Archive agent entry must be an object")
+
+    agent_id = agent.get("id")
+    version = agent.get("version")
+    icon = agent.get("icon")
+
+    if not isinstance(agent_id, str) or not agent_id:
+        raise ValueError("Archive agent entry is missing id")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"Archive agent {agent_id} is missing version")
+    if icon is not None and (not isinstance(icon, str) or not icon):
+        raise ValueError(f"Archive agent {agent_id} has an invalid icon value")
+
+    archived_agent = archive_by_id.setdefault(
+        agent_id,
+        {
+            "id": agent_id,
+            "icon": None,
+            "versions": {},
+        },
+    )
+    if isinstance(icon, str) and icon:
+        archived_agent["icon"] = icon
+    archived_agent["versions"][version] = strip_icon(agent)
+
+
+def _finalize_archive(archive_by_id: dict[str, dict]) -> dict:
+    """Convert the mutable archive index into the published JSON shape."""
+    archived_agents = []
+    for agent_id, archived_agent in sorted(archive_by_id.items()):
+        versions = list(archived_agent["versions"].values())
+        versions.sort(key=lambda entry: version_sort_key(entry["version"]))
+        archived_entry = {
+            "id": agent_id,
+            "versions": versions,
+        }
+        if isinstance(archived_agent["icon"], str) and archived_agent["icon"]:
+            archived_entry["icon"] = archived_agent["icon"]
+        archived_agents.append(archived_entry)
+
+    return {"version": ARCHIVE_VERSION, "agents": archived_agents}
+
+
+def build_archive_from_snapshots(snapshots: list[dict]) -> dict:
+    """Merge historical registry snapshots into registry-archive.json format."""
+    archive_by_id: dict[str, dict] = {}
+
+    for snapshot in snapshots:
+        agents = snapshot.get("agents")
+        if not isinstance(agents, list):
+            raise ValueError("Snapshot is missing an agents list")
+        for agent in agents:
+            _merge_agent_into_archive(archive_by_id, agent)
+
+    return _finalize_archive(archive_by_id)
+
+
+def build_registry_archive(
+    current_agents: list[dict], previous_archive: dict | None = None
+) -> dict:
+    """Merge the current registry snapshot into a previous registry archive."""
+    archive_by_id: dict[str, dict] = {}
+
+    if previous_archive is not None:
+        errors = validate_registry_archive(previous_archive)
+        if errors:
+            raise ValueError(
+                "Invalid previous archive:\n" + "\n".join(f"- {error}" for error in errors)
+            )
+
+        for archived_agent in previous_archive["agents"]:
+            agent_id = archived_agent["id"]
+            icon = archived_agent.get("icon")
+            if icon is not None and (not isinstance(icon, str) or not icon):
+                raise ValueError(f"Archived agent {agent_id} has an invalid icon value")
+
+            archive_by_id[agent_id] = {
+                "id": agent_id,
+                "icon": copy.deepcopy(icon) if icon is not None else None,
+                "versions": {
+                    entry["version"]: copy.deepcopy(entry) for entry in archived_agent["versions"]
+                },
+            }
+
+    for agent in current_agents:
+        _merge_agent_into_archive(archive_by_id, agent)
+
+    return _finalize_archive(archive_by_id)
+
+
+def validate_registry_archive(archive: dict) -> list[str]:
+    """Validate registry-archive.json structure and invariants."""
+    errors = []
+
+    if not isinstance(archive, dict):
+        return ["Archive root must be an object"]
+
+    version = archive.get("version")
+    if not isinstance(version, str) or not version:
+        errors.append("Archive root is missing version")
+
+    agents = archive.get("agents")
+    if not isinstance(agents, list):
+        return errors + ["Archive root is missing agents list"]
+
+    seen_ids = set()
+    for agent in agents:
+        if not isinstance(agent, dict):
+            errors.append("Archived agent must be an object")
+            continue
+
+        agent_id = agent.get("id")
+        if not isinstance(agent_id, str) or not agent_id:
+            errors.append("Archived agent is missing id")
+            continue
+        if agent_id in seen_ids:
+            errors.append(f"Duplicate archived agent id: {agent_id}")
+        seen_ids.add(agent_id)
+
+        icon = agent.get("icon")
+        if icon is not None and (not isinstance(icon, str) or not icon):
+            errors.append(f"Archived agent {agent_id} has an invalid icon value")
+
+        versions = agent.get("versions")
+        if not isinstance(versions, list) or not versions:
+            errors.append(f"Archived agent {agent_id} must have a non-empty versions list")
+            continue
+
+        seen_versions = set()
+        previous_key = None
+        for entry in versions:
+            if not isinstance(entry, dict):
+                errors.append(f"Archived agent {agent_id} has a non-object version entry")
+                continue
+
+            entry_id = entry.get("id")
+            if entry_id != agent_id:
+                errors.append(f"Archived version for {agent_id} has mismatched id: {entry_id}")
+
+            entry_version = entry.get("version")
+            if not isinstance(entry_version, str) or not entry_version:
+                errors.append(f"Archived agent {agent_id} has a version entry without version")
+                continue
+
+            if entry_version in seen_versions:
+                errors.append(f"Archived agent {agent_id} has duplicate version {entry_version}")
+            seen_versions.add(entry_version)
+
+            key = version_sort_key(entry_version)
+            if previous_key is not None and key < previous_key:
+                errors.append(f"Archived agent {agent_id} versions are not sorted")
+            previous_key = key
+
+    return errors
+
+
+def validate_registry_archive_sync(current_agents: list[dict], archive: dict) -> list[str]:
+    """Validate that the current registry snapshot is represented exactly in the archive."""
+    errors = []
+
+    archive_errors = validate_registry_archive(archive)
+    if archive_errors:
+        return archive_errors
+
+    archive_by_id = {agent["id"]: agent for agent in archive["agents"]}
+
+    for agent in current_agents:
+        agent_id = agent["id"]
+        agent_version = agent["version"]
+        archived_agent = archive_by_id.get(agent_id)
+
+        if archived_agent is None:
+            errors.append(f"Current agent {agent_id} is missing from registry-archive.json")
+            continue
+
+        current_icon = agent.get("icon")
+        archive_icon = archived_agent.get("icon")
+        if current_icon != archive_icon:
+            errors.append(f"Current agent {agent_id} icon does not match registry-archive.json")
+
+        archived_entry = next(
+            (entry for entry in archived_agent["versions"] if entry["version"] == agent_version),
+            None,
+        )
+        if archived_entry is None:
+            errors.append(
+                f"Current agent {agent_id} version {agent_version} is missing from "
+                f"registry-archive.json"
+            )
+            continue
+
+        if strip_icon(agent) != archived_entry:
+            errors.append(
+                f"Current agent {agent_id} version {agent_version} differs from "
+                f"registry-archive.json"
+            )
+
+    return errors
+
+
+def load_registry_archive(path: Path | None) -> dict | None:
+    """Load and validate a registry archive file if it exists."""
+    if path is None or not path.exists():
+        return None
+
+    archive = json.loads(path.read_text())
+    errors = validate_registry_archive(archive)
+    if errors:
+        raise ValueError(
+            f"Invalid registry archive at {path}:\n" + "\n".join(f"- {error}" for error in errors)
+        )
+    return archive

--- a/.github/workflows/tests/test_backfill_registry_archive.py
+++ b/.github/workflows/tests/test_backfill_registry_archive.py
@@ -1,0 +1,339 @@
+"""Tests for registry archive backfill logic."""
+
+from backfill_registry_archive import find_registry_asset_url
+from registry_archive import (
+    build_archive_from_snapshots,
+    build_registry_archive,
+    validate_registry_archive,
+    validate_registry_archive_sync,
+)
+
+
+class TestFindRegistryAssetUrl:
+    def test_returns_registry_asset_download_url(self):
+        release = {
+            "assets": [
+                {"name": "agent.schema.json", "browser_download_url": "https://example/schema"},
+                {"name": "registry.json", "browser_download_url": "https://example/registry"},
+            ]
+        }
+
+        assert find_registry_asset_url(release) == "https://example/registry"
+
+    def test_returns_none_when_registry_asset_is_absent(self):
+        release = {"assets": [{"name": "agent.schema.json", "browser_download_url": "x"}]}
+
+        assert find_registry_asset_url(release) is None
+
+
+class TestBuildArchiveFromSnapshots:
+    def test_groups_entries_by_agent_and_sorts_versions(self):
+        snapshots = [
+            {
+                "agents": [
+                    {
+                        "id": "codex-acp",
+                        "name": "Codex CLI",
+                        "version": "0.10.0",
+                        "description": "desc",
+                        "icon": "https://cdn.example/codex.svg",
+                        "distribution": {"npx": {"package": "@zed/codex@0.10.0"}},
+                    },
+                    {
+                        "id": "claude-acp",
+                        "name": "Claude",
+                        "version": "0.29.0",
+                        "description": "desc",
+                        "icon": "https://cdn.example/claude.svg",
+                        "distribution": {"npx": {"package": "@anthropic/claude@0.29.0"}},
+                    },
+                ]
+            },
+            {
+                "agents": [
+                    {
+                        "id": "codex-acp",
+                        "name": "Codex CLI",
+                        "version": "0.9.2",
+                        "description": "desc",
+                        "icon": "https://cdn.example/codex-old.svg",
+                        "distribution": {
+                            "binary": {"darwin-aarch64": {"archive": "a", "cmd": "b"}}
+                        },
+                    },
+                    {
+                        "id": "codex-acp",
+                        "name": "Codex CLI",
+                        "version": "0.11.1",
+                        "description": "desc",
+                        "icon": "https://cdn.example/codex-new.svg",
+                        "distribution": {
+                            "binary": {"darwin-aarch64": {"archive": "c", "cmd": "d"}}
+                        },
+                    },
+                ]
+            },
+        ]
+
+        archive = build_archive_from_snapshots(snapshots)
+
+        assert archive["version"] == "1.0.0"
+        assert [agent["id"] for agent in archive["agents"]] == ["claude-acp", "codex-acp"]
+
+        codex = archive["agents"][1]
+        assert codex["icon"] == "https://cdn.example/codex-new.svg"
+        assert [entry["version"] for entry in codex["versions"]] == ["0.9.2", "0.10.0", "0.11.1"]
+        assert all("icon" not in entry for entry in codex["versions"])
+
+    def test_replaces_duplicate_version_with_latest_published_entry(self):
+        snapshots = [
+            {
+                "agents": [
+                    {
+                        "id": "codex-acp",
+                        "name": "Codex CLI",
+                        "version": "0.9.3",
+                        "description": "old",
+                        "icon": "https://cdn.example/codex.svg",
+                        "distribution": {
+                            "binary": {"darwin-aarch64": {"archive": "old", "cmd": "b"}}
+                        },
+                    }
+                ]
+            },
+            {
+                "agents": [
+                    {
+                        "id": "codex-acp",
+                        "name": "Codex CLI",
+                        "version": "0.9.3",
+                        "description": "new",
+                        "icon": "https://cdn.example/codex.svg",
+                        "distribution": {"npx": {"package": "@zed/codex@0.9.3"}},
+                    }
+                ]
+            },
+        ]
+
+        archive = build_archive_from_snapshots(snapshots)
+
+        codex_versions = archive["agents"][0]["versions"]
+        assert len(codex_versions) == 1
+        assert codex_versions[0]["description"] == "new"
+        assert codex_versions[0]["distribution"] == {"npx": {"package": "@zed/codex@0.9.3"}}
+
+    def test_preserves_agent_when_some_snapshots_omit_icon(self):
+        snapshots = [
+            {
+                "agents": [
+                    {
+                        "id": "minion-code",
+                        "name": "Minion Code",
+                        "version": "0.1.43",
+                        "description": "desc",
+                        "distribution": {"uvx": {"package": "minion-code@0.1.43"}},
+                    }
+                ]
+            },
+            {
+                "agents": [
+                    {
+                        "id": "minion-code",
+                        "name": "Minion Code",
+                        "version": "0.1.44",
+                        "description": "desc",
+                        "icon": "https://cdn.example/minion-code.svg",
+                        "distribution": {"uvx": {"package": "minion-code@0.1.44"}},
+                    }
+                ]
+            },
+        ]
+
+        archive = build_archive_from_snapshots(snapshots)
+
+        minion = archive["agents"][0]
+        assert minion["id"] == "minion-code"
+        assert minion["icon"] == "https://cdn.example/minion-code.svg"
+        assert [entry["version"] for entry in minion["versions"]] == ["0.1.43", "0.1.44"]
+
+
+class TestBuildRegistryArchive:
+    def test_merges_current_agents_into_previous_archive(self):
+        previous_archive = {
+            "version": "1.0.0",
+            "agents": [
+                {
+                    "id": "codex-acp",
+                    "icon": "https://cdn.example/codex-old.svg",
+                    "versions": [
+                        {
+                            "id": "codex-acp",
+                            "name": "Codex CLI",
+                            "version": "0.9.2",
+                            "description": "desc",
+                            "distribution": {
+                                "binary": {"darwin-aarch64": {"archive": "a", "cmd": "b"}}
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        current_agents = [
+            {
+                "id": "codex-acp",
+                "name": "Codex CLI",
+                "version": "0.11.1",
+                "description": "desc",
+                "icon": "https://cdn.example/codex-new.svg",
+                "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+            },
+            {
+                "id": "claude-acp",
+                "name": "Claude",
+                "version": "0.30.0",
+                "description": "desc",
+                "icon": "https://cdn.example/claude.svg",
+                "distribution": {"npx": {"package": "@anthropic/claude@0.30.0"}},
+            },
+        ]
+
+        archive = build_registry_archive(current_agents, previous_archive)
+
+        assert [agent["id"] for agent in archive["agents"]] == ["claude-acp", "codex-acp"]
+        codex = archive["agents"][1]
+        assert codex["icon"] == "https://cdn.example/codex-new.svg"
+        assert [entry["version"] for entry in codex["versions"]] == ["0.9.2", "0.11.1"]
+        assert all("icon" not in entry for entry in codex["versions"])
+
+    def test_validate_registry_archive_flags_unsorted_versions(self):
+        archive = {
+            "version": "1.0.0",
+            "agents": [
+                {
+                    "id": "codex-acp",
+                    "versions": [
+                        {
+                            "id": "codex-acp",
+                            "name": "Codex CLI",
+                            "version": "0.11.1",
+                            "description": "desc",
+                            "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+                        },
+                        {
+                            "id": "codex-acp",
+                            "name": "Codex CLI",
+                            "version": "0.9.2",
+                            "description": "desc",
+                            "distribution": {
+                                "binary": {"darwin-aarch64": {"archive": "a", "cmd": "b"}}
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+
+        errors = validate_registry_archive(archive)
+
+        assert errors == ["Archived agent codex-acp versions are not sorted"]
+
+    def test_validate_registry_archive_sync_accepts_matching_current_entry(self):
+        current_agents = [
+            {
+                "id": "codex-acp",
+                "name": "Codex CLI",
+                "version": "0.11.1",
+                "description": "desc",
+                "icon": "https://cdn.example/codex.svg",
+                "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+            }
+        ]
+        archive = {
+            "version": "1.0.0",
+            "agents": [
+                {
+                    "id": "codex-acp",
+                    "icon": "https://cdn.example/codex.svg",
+                    "versions": [
+                        {
+                            "id": "codex-acp",
+                            "name": "Codex CLI",
+                            "version": "0.11.1",
+                            "description": "desc",
+                            "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+                        }
+                    ],
+                }
+            ],
+        }
+
+        assert validate_registry_archive_sync(current_agents, archive) == []
+
+    def test_validate_registry_archive_sync_reports_entry_mismatch(self):
+        current_agents = [
+            {
+                "id": "codex-acp",
+                "name": "Codex CLI",
+                "version": "0.11.1",
+                "description": "new",
+                "icon": "https://cdn.example/codex.svg",
+                "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+            }
+        ]
+        archive = {
+            "version": "1.0.0",
+            "agents": [
+                {
+                    "id": "codex-acp",
+                    "icon": "https://cdn.example/codex.svg",
+                    "versions": [
+                        {
+                            "id": "codex-acp",
+                            "name": "Codex CLI",
+                            "version": "0.11.1",
+                            "description": "old",
+                            "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+                        }
+                    ],
+                }
+            ],
+        }
+
+        assert validate_registry_archive_sync(current_agents, archive) == [
+            "Current agent codex-acp version 0.11.1 differs from registry-archive.json"
+        ]
+
+    def test_validate_registry_archive_sync_reports_icon_mismatch(self):
+        current_agents = [
+            {
+                "id": "codex-acp",
+                "name": "Codex CLI",
+                "version": "0.11.1",
+                "description": "desc",
+                "icon": "https://cdn.example/codex-new.svg",
+                "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+            }
+        ]
+        archive = {
+            "version": "1.0.0",
+            "agents": [
+                {
+                    "id": "codex-acp",
+                    "icon": "https://cdn.example/codex-old.svg",
+                    "versions": [
+                        {
+                            "id": "codex-acp",
+                            "name": "Codex CLI",
+                            "version": "0.11.1",
+                            "description": "desc",
+                            "distribution": {"npx": {"package": "@zed/codex@0.11.1"}},
+                        }
+                    ],
+                }
+            ],
+        }
+
+        assert validate_registry_archive_sync(current_agents, archive) == [
+            "Current agent codex-acp icon does not match registry-archive.json"
+        ]

--- a/registry-archive.schema.json
+++ b/registry-archive.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cdn.agentclientprotocol.com/registry/v1/latest/registry-archive.schema.json",
+  "title": "ACP Agent Registry Archive",
+  "description": "Schema for the archive of all published ACP agent versions",
+  "type": "object",
+  "required": ["version", "agents"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Registry archive schema version"
+    },
+    "agents": {
+      "type": "array",
+      "description": "Agents grouped by id, each containing all published versions",
+      "items": {
+        "$ref": "#/definitions/archivedAgent"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "archivedAgent": {
+      "type": "object",
+      "required": ["id", "versions"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Unique agent identifier"
+        },
+        "icon": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical icon URL shared across all archived versions of the agent"
+        },
+        "versions": {
+          "type": "array",
+          "minItems": 1,
+          "description": "All archived published versions for this agent",
+          "items": {
+            "$ref": "agent.schema.json"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `registry-archive` support to the registry build, including incremental merge logic and sync validation against the current `registry.json`
- add a one-off backfill script plus a checked-in bootstrap seed built from published release snapshots
- publish `registry-archive.json` and `registry-archive.schema.json` alongside the existing registry artifacts

## Why
The registry already publishes immutable historical snapshots, but there was no cumulative index of all published agent versions. This change bootstraps that archive once and then keeps it current incrementally on each build.

## Impact
Clients can resolve historical install/run metadata for old agent versions from a single archive file, while the build now fails if the current registry snapshot and archive drift apart.

## Validation
- `cd .github/workflows && uv run --with pytest pytest tests/test_backfill_registry_archive.py -q`
- `cd .github/workflows && uv run --with ruff ruff check registry_archive.py build_registry.py tests/test_backfill_registry_archive.py backfill_registry_archive.py`
- `SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py --dry-run --previous-archive .github/workflows/bootstrap/registry-archive.seed.json`
- `SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py --previous-archive .github/workflows/bootstrap/registry-archive.seed.json`
