### PR TITLE
Add pi-sdk-acp-adapter

### DIFF
--- a/pi-sdk-acp-adapter/agent.json
+++ b/pi-sdk-acp-adapter/agent.json
@@ -1,0 +1,16 @@
+{
+  "id": "pi-sdk-acp-adapter",
+  "name": "Pi Coding Agent",
+  "version": "0.1.6",
+  "description": "ACP adapter for Pi Coding Agent SDK.",
+  "repository": "https://github.com/frmhd/pi-sdk-acp-adapter",
+  "website": "https://github.com/frmhd/pi-sdk-acp-adapter#readme",
+  "authors": ["Mario Zechner", "frmhd"],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "@frmhd/pi-sdk-acp-adapter@0.1.6",
+      "args": []
+    }
+  }
+}

--- a/pi-sdk-acp-adapter/icon.svg
+++ b/pi-sdk-acp-adapter/icon.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1H11.7692V7.9999H8.17942V11.4999H4.58982V15H1V1ZM4.58982 4.50005V7.9999H8.17942V4.50005H4.58982Z" fill="currentColor"/>
+<path d="M11.7692 7.46154H15V15H11.7692V7.46154Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Pi Coding Agent SDK adapter** (`pi-sdk-acp-adapter`) to the ACP registry.

## About

ACP adapter for the [Pi Coding Agent](https://pi.dev). Bridges Pi to ACP-compatible clients such as Zed, JetBrains IDEs, and Obsidian with the Agent Client plugin.

- **npm**: [`@frmhd/pi-sdk-acp-adapter`](https://www.npmjs.com/package/@frmhd/pi-sdk-acp-adapter)
- **Repository**: https://github.com/frmhd/pi-sdk-acp-adapter
- **License**: MIT
- **Authors**: Mario Zechner, frmhd

## Difference from `pi-acp`

There is an existing [`pi-acp`](https://github.com/svkozak/pi-acp) entry in the registry that wraps Pi via a **subprocess bridge**. This entry (`pi-sdk-acp-adapter`) is an **ACP adapter built directly on Pi's SDK** with a focus on richer client integration:

- **File paths** — proper file path reporting for client navigation
- **Native terminal outputs** — via delegation for live output streaming in the client
- **FS operations delegation** — for proper diff display in ACP clients

## Distribution

npx (`@frmhd/pi-sdk-acp-adapter`)

## Files Added

- `pi-sdk-acp-adapter/agent.json` — Agent metadata and distribution info
- `pi-sdk-acp-adapter/icon.svg` — 16×16 monochrome Pi logo using `currentColor`
