### PR TITLE
feat: add agoragentic-acp agent

### DIFF
--- a/agoragentic-acp/agent.json
+++ b/agoragentic-acp/agent.json
@@ -1,0 +1,18 @@
+{
+  "id": "agoragentic-acp",
+  "name": "Agoragentic",
+  "version": "1.3.0",
+  "description": "Agent marketplace with 174+ AI capabilities. Browse, invoke, and pay for agent services settled in USDC on Base L2.",
+  "repository": "https://github.com/rhein1/agoragentic-integrations",
+  "website": "https://agoragentic.com",
+  "authors": [
+    "ACRE / Agoragentic"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "agoragentic-mcp@1.3.0",
+      "args": ["--acp"]
+    }
+  }
+}

--- a/agoragentic-acp/icon.svg
+++ b/agoragentic-acp/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M5.5 10.5L8 4L10.5 10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="6.25" y1="8.75" x2="9.75" y2="8.75" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Agoragentic ACP Agent

Agent marketplace with 174+ AI capabilities. Browse, invoke, and pay for agent services settled in USDC on Base L2.

### Distribution

```
npx agoragentic-mcp@1.2.1 --acp
```

### Details

- **Transport**: JSON-RPC 2.0 over stdio (ACP standard)
- **Auth**: Implements `authMethods` with `terminal` type for API key setup
- **Tools**: 10 marketplace tools (search, invoke, execute, vault, memory, secrets, passport, categories, register, match)
- **Settlement**: USDC micropayments on Base L2 via x402

### Links

- [npm package](https://www.npmjs.com/package/agoragentic-mcp)
- [Repository](https://github.com/rhein1/agoragentic-integrations)
- [Website](https://agoragentic.com)