### PR TITLE
Update factory-droid to use --output-format acp-daemon

### DIFF
--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -14,7 +14,7 @@
       "args": [
         "exec",
         "--output-format",
-        "acp"
+        "acp-daemon"
       ],
       "env": {
         "DROID_DISABLE_AUTO_UPDATE": "true",


### PR DESCRIPTION
Switches the factory-droid spawn args from `exec --output-format acp` to `exec --output-format acp-daemon`.

The `acp-daemon` transport runs the ACP adapter in a daemon process that multiplexes multiple ACP sessions over a single `droid` invocation, which gives clients better concurrency and lower per-session startup overhead while remaining wire-compatible with the existing ACP transport.