### PR TITLE
Remove poolside repo to fix releases check

### DIFF
--- a/poolside/agent.json
+++ b/poolside/agent.json
@@ -3,7 +3,6 @@
   "name": "Poolside",
   "version": "1.0.0",
   "description": "Poolside's coding agent",
-  "repository": "https://github.com/poolsideai/pool",
   "website": "https://poolside.ai",
   "authors": ["Poolside <feedback@poolside.ai>"],
   "license": "proprietary",


### PR DESCRIPTION
We use this field to check for binary releases, so just going to remove for now