### PR TITLE
fix(cortex-code): bump to v1.0.73 and fix binary cmd path

### DIFF
--- a/cortex-code/agent.json
+++ b/cortex-code/agent.json
@@ -1,62 +1,42 @@
 {
   "id": "cortex-code",
-  "name": "Snowflake Cortex Code",
+  "name": "Cortex Code",
   "version": "1.0.73",
   "description": "Snowflake's Cortex Code coding agent",
   "repository": "https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code",
-  "authors": [
-    "Snowflake"
-  ],
+  "authors": ["Snowflake"],
   "license": "proprietary",
   "distribution": {
     "binary": {
       "darwin-aarch64": {
         "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-arm64.tar.gz",
         "cmd": "coco-1.0.73+180523.e6179a031de9-darwin-arm64/cortex",
-        "args": [
-          "acp",
-          "serve"
-        ]
+        "args": ["acp", "serve"]
       },
       "darwin-x86_64": {
         "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-amd64.tar.gz",
         "cmd": "coco-1.0.73+180523.e6179a031de9-darwin-amd64/cortex",
-        "args": [
-          "acp",
-          "serve"
-        ]
+        "args": ["acp", "serve"]
       },
       "linux-x86_64": {
         "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-amd64.tar.gz",
         "cmd": "coco-1.0.73+180523.e6179a031de9-linux-amd64/cortex",
-        "args": [
-          "acp",
-          "serve"
-        ]
+        "args": ["acp", "serve"]
       },
       "linux-aarch64": {
         "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-arm64.tar.gz",
         "cmd": "coco-1.0.73+180523.e6179a031de9-linux-arm64/cortex",
-        "args": [
-          "acp",
-          "serve"
-        ]
+        "args": ["acp", "serve"]
       },
       "windows-x86_64": {
         "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-amd64.tar.gz",
         "cmd": "coco-1.0.73+180523.e6179a031de9-windows-amd64/cortex.exe",
-        "args": [
-          "acp",
-          "serve"
-        ]
+        "args": ["acp", "serve"]
       },
       "windows-aarch64": {
         "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-arm64.tar.gz",
         "cmd": "coco-1.0.73+180523.e6179a031de9-windows-arm64/cortex.exe",
-        "args": [
-          "acp",
-          "serve"
-        ]
+        "args": ["acp", "serve"]
       }
     }
   }

--- a/cortex-code/agent.json
+++ b/cortex-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "cortex-code",
   "name": "Snowflake Cortex Code",
-  "version": "1.0.58",
+  "version": "1.0.73",
   "description": "Snowflake's Cortex Code coding agent",
   "repository": "https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code",
   "authors": [
@@ -11,48 +11,48 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.58%2B183258.b9d8c6466577/coco-1.0.58%2B183258.b9d8c6466577-darwin-arm64.tar.gz",
-        "cmd": "./cortex",
+        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-arm64.tar.gz",
+        "cmd": "coco-1.0.73+180523.e6179a031de9-darwin-arm64/cortex",
         "args": [
           "acp",
           "serve"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.58%2B183258.b9d8c6466577/coco-1.0.58%2B183258.b9d8c6466577-darwin-amd64.tar.gz",
-        "cmd": "./cortex",
+        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-amd64.tar.gz",
+        "cmd": "coco-1.0.73+180523.e6179a031de9-darwin-amd64/cortex",
         "args": [
           "acp",
           "serve"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.58%2B183258.b9d8c6466577/coco-1.0.58%2B183258.b9d8c6466577-linux-amd64.tar.gz",
-        "cmd": "./cortex",
+        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-amd64.tar.gz",
+        "cmd": "coco-1.0.73+180523.e6179a031de9-linux-amd64/cortex",
         "args": [
           "acp",
           "serve"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.58%2B183258.b9d8c6466577/coco-1.0.58%2B183258.b9d8c6466577-linux-arm64.tar.gz",
-        "cmd": "./cortex",
+        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-arm64.tar.gz",
+        "cmd": "coco-1.0.73+180523.e6179a031de9-linux-arm64/cortex",
         "args": [
           "acp",
           "serve"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.58%2B183258.b9d8c6466577/coco-1.0.58%2B183258.b9d8c6466577-windows-amd64.tar.gz",
-        "cmd": "./cortex.exe",
+        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-amd64.tar.gz",
+        "cmd": "coco-1.0.73+180523.e6179a031de9-windows-amd64/cortex.exe",
         "args": [
           "acp",
           "serve"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.58%2B183258.b9d8c6466577/coco-1.0.58%2B183258.b9d8c6466577-windows-arm64.tar.gz",
-        "cmd": "./cortex.exe",
+        "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-arm64.tar.gz",
+        "cmd": "coco-1.0.73+180523.e6179a031de9-windows-arm64/cortex.exe",
         "args": [
           "acp",
           "serve"


### PR DESCRIPTION
## Summary

- Bumps Cortex Code from `v1.0.58` to `v1.0.73` (`1.0.73+180523.e6179a031de9`) across all 6 platforms
- Fixes the `cmd` path that caused `Missing command .../cortex after extraction` on clean Zed installs (reported in zed-industries/zed#55356, root-caused in #242)

## Root cause

The Cortex Code tarball extracts into a versioned subdirectory:

```
coco-1.0.73+180523.e6179a031de9-darwin-arm64/
└── cortex
```

Zed resolves `cmd` relative to the extraction root (`<version_dir>`), so `"./cortex"` pointed to `<version_dir>/cortex` which does not exist. The binary actually lands at `<version_dir>/coco-{version}-{platform}/cortex`.

## Fix

Updated `cmd` for all 6 platforms to include the versioned subdirectory prefix:

| Platform | Before | After |
|---|---|---|
| `darwin-aarch64` | `./cortex` | `coco-1.0.73+180523.e6179a031de9-darwin-arm64/cortex` |
| `darwin-x86_64` | `./cortex` | `coco-1.0.73+180523.e6179a031de9-darwin-amd64/cortex` |
| `linux-x86_64` | `./cortex` | `coco-1.0.73+180523.e6179a031de9-linux-amd64/cortex` |
| `linux-aarch64` | `./cortex` | `coco-1.0.73+180523.e6179a031de9-linux-arm64/cortex` |
| `windows-x86_64` | `./cortex.exe` | `coco-1.0.73+180523.e6179a031de9-windows-amd64/cortex.exe` |
| `windows-aarch64` | `./cortex.exe` | `coco-1.0.73+180523.e6179a031de9-windows-arm64/cortex.exe` |

## Test plan

- [x] Verified tarball extraction layout by streaming all 6 platform archives (`curl | tar -tzf -`)
- [x] Tested `cmd` path on darwin-arm64: extracted to temp dir and executed `coco-1.0.73+180523.e6179a031de9-darwin-arm64/cortex --version` → `Cortex Code v0.26.0430`
- [x] Confirmed no `1.0.58` references remain in `agent.json`
- [x] JSON valid (`python3 -m json.tool`)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

Co-Authored-By: Cortex Code <noreply@snowflake.com>
