### PR TITLE
feat: add Aegis to ACP registry

### DIFF
--- a/aegis/agent.json
+++ b/aegis/agent.json
@@ -1,0 +1,16 @@
+{
+  "id": "aegis",
+  "name": "Aegis",
+  "version": "0.6.7",
+  "description": "Enterprise orchestration middleware for Claude Code — REST API, MCP server, SSE, webhooks, and dashboard",
+  "repository": "https://github.com/OneStepAt4time/aegis",
+  "website": "https://github.com/OneStepAt4time/aegis#readme",
+  "authors": ["OneStepAt4time"],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "@onestepat4time/aegis@0.6.7",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/aegis/agent.json
+++ b/aegis/agent.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/OneStepAt4time/aegis",
   "website": "https://github.com/OneStepAt4time/aegis#readme",
   "authors": ["OneStepAt4time"],
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "distribution": {
     "npx": {
       "package": "@onestepat4time/aegis@0.6.7",

--- a/aegis/icon.svg
+++ b/aegis/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 1L2 3.5v4.5c0 3.3 2.7 6 6 7 3.3-1 6-3.7 6-7V3.5L8 1zm0 1.4l4.5 2v3.6c0 2.5-1.9 4.5-4.5 5.4-2.6-.9-4.5-2.9-4.5-5.4V4.4L8 2.4zM7 5v3h2V5H7zm0 4v2h2V9H7z"/>
+</svg>


### PR DESCRIPTION
## Register Aegis

Adds Aegis to the ACP registry.

### agent.json
- **id:** aegis
- **name:** Aegis
- **version:** 0.6.7
- **description:** Enterprise orchestration middleware for Claude Code — REST API, MCP server, SSE, webhooks, and dashboard
- **license:** AGPL-3.0
- **distribution:** `npx @onestepat4time/aegis@0.6.7 mcp`

### Checklist
- [x] agent.json follows schema
- [x] icon.svg is 16x16 monochrome (currentColor)
- [x] ACP initialize returns valid authMethods
- [x] Package published on npm (`@onestepat4time/aegis`)

Closes OneStepAt4time/aegis#3018