### PR TITLE
Quarantine qoder auto-update

### DIFF
--- a/quarantine.json
+++ b/quarantine.json
@@ -4,5 +4,6 @@
   "junie": "Auto-update disabled",
   "mistral-vibe": "missing windows build",
   "minion-code": "Python dependency issue",
+  "qoder": "ACP initialize fails in qodercli 0.2.15/0.2.16",
   "vtcode": "Missing windows builds"
 }


### PR DESCRIPTION
## Summary
- add qoder to quarantine.json so automated version updates skip it
- document the current ACP initialize failure in qodercli 0.2.15/0.2.16

## Why
Scheduled Update Agent Versions runs keep failing when qoder is updated from 0.2.14 to the current latest release. The auth verification step receives an ACP initialize error: `Cannot read properties of undefined (reading run)`.

## Validation
- `python3 .github/workflows/update_versions.py --agents qoder --json`
- `python3 .github/workflows/verify_agents.py --list-ids`
- `uv run --with jsonschema .github/workflows/build_registry.py --dry-run`