### PR TITLE
feat: add Chump to ACP Registry

### DIFF
--- a/chump/agent.json
+++ b/chump/agent.json
@@ -1,0 +1,36 @@
+{
+  "id": "chump",
+  "name": "Chump",
+  "version": "0.1.2",
+  "description": "Self-hosted local-first AI coding agent with fleet coordination, SQLite state, and ACP v1+v2 support. Runs fully offline on local LLMs or with any OpenAI-compatible inference backend.",
+  "repository": "https://github.com/repairman29/chump",
+  "website": "https://repairman29.github.io/chump/",
+  "authors": [
+    "repairman29"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/repairman29/chump/releases/download/v0.1.2/chump-aarch64-apple-darwin.tar.xz",
+        "cmd": "./chump",
+        "args": ["--acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/repairman29/chump/releases/download/v0.1.2/chump-x86_64-apple-darwin.tar.xz",
+        "cmd": "./chump",
+        "args": ["--acp"]
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/repairman29/chump/releases/download/v0.1.2/chump-aarch64-unknown-linux-gnu.tar.xz",
+        "cmd": "./chump",
+        "args": ["--acp"]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/repairman29/chump/releases/download/v0.1.2/chump-x86_64-unknown-linux-gnu.tar.xz",
+        "cmd": "./chump",
+        "args": ["--acp"]
+      }
+    }
+  }
+}

--- a/chump/icon.svg
+++ b/chump/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <!-- Chump icon: stylized "C" bracket with a circuit node — represents a local-first agent -->
+  <path fill="currentColor" d="M3 2h2v1H4v10h1v1H3V2zm8 0h2v12h-2v-1h1V3h-1V2zM6 7h4v2H6V7z"/>
+</svg>


### PR DESCRIPTION
## Add Chump to the ACP Agent Registry

**Chump** is a self-hosted, local-first AI coding agent written in Rust. It implements ACP v1+v2 over stdio (`chump --acp`) and runs fully offline on local LLMs or any OpenAI-compatible inference backend.

### Agent details

- **ID:** `chump`
- **Launch command:** `chump --acp`
- **Auth:** Terminal auth (local-first binary, trusts invoking shell environment)
- **ACP versions:** v1 + v2 (initialize, session/new, session/prompt, session/cancel, session/set_mode, session/set_config_option, bidirectional fs/* and terminal/* RPCs)
- **License:** MIT
- **Repository:** https://github.com/repairman29/chump

### Install instructions (for users)

```bash
brew tap repairman29/chump
brew install chump
chump init
```

Or download directly from [GitHub Releases](https://github.com/repairman29/chump/releases/tag/v0.1.2).

### Platforms

| Platform | Archive |
|---|---|
| macOS (Apple Silicon) | `chump-aarch64-apple-darwin.tar.xz` |
| macOS (Intel) | `chump-x86_64-apple-darwin.tar.xz` |
| Linux (ARM64) | `chump-aarch64-unknown-linux-gnu.tar.xz` |
| Linux (x86_64) | `chump-x86_64-unknown-linux-gnu.tar.xz` |

### Checklist

- [x] `agent.json` validates against `agent.schema.json`
- [x] `icon.svg` is 16x16, monochrome, uses `currentColor` only
- [x] Binary URLs are accessible (GitHub releases v0.1.2)
- [x] Agent returns `authMethods` with `type: "terminal"` in `initialize` response
- [x] `id` matches directory name
- [x] Version is semver format