### PR TITLE
feat: add Antigravity CLI support to ACP registry

### DIFF
--- a/antigravity/agent.json
+++ b/antigravity/agent.json
@@ -1,0 +1,55 @@
+{
+  "id": "antigravity",
+  "name": "Antigravity CLI",
+  "version": "1.0.0",
+  "description": "Google's agent-first development platform and runtime, designed for autonomous multi-agent workflows.",
+  "website": "https://antigravity.google",
+  "authors": [
+    "Google"
+  ],
+  "license": "proprietary",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/darwin-arm/cli_mac_arm64.tar.gz",
+        "cmd": "./antigravity",
+        "args": [
+          "acp",
+          "--print"
+        ]
+      },
+      "darwin-x86_64": {
+        "archive": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/darwin-x64/cli_mac_x64.tar.gz",
+        "cmd": "./antigravity",
+        "args": [
+          "acp",
+          "--print"
+        ]
+      },
+      "linux-aarch64": {
+        "archive": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/linux-arm/cli_linux_arm64.tar.gz",
+        "cmd": "./antigravity",
+        "args": [
+          "acp",
+          "--print"
+        ]
+      },
+      "linux-x86_64": {
+        "archive": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/linux-x64/cli_linux_x64.tar.gz",
+        "cmd": "./antigravity",
+        "args": [
+          "acp",
+          "--print"
+        ]
+      },
+      "windows-x86_64": {
+        "archive": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/windows-x64/cli_windows_x64.exe",
+        "cmd": "./cli_windows_x64.exe",
+        "args": [
+          "acp",
+          "--print"
+        ]
+      }
+    }
+  }
+}

--- a/antigravity/icon.svg
+++ b/antigravity/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 3L2 13h2.2l3.8-6.5 3.8 6.5H14L8 3z"/>
+  <circle fill="currentColor" cx="8" cy="14" r="1"/>
+</svg>


### PR DESCRIPTION
This PR adds support for the new Antigravity CLI (`agy`) to the ACP registry. It includes the `agent.json` definition and a custom monochrome icon. The agent is configured with the `--print` flag to ensure clean protocol responses for IDE integration.\n\n**Meta note:**

This PR was actually built and submitted using the `agy` CLI itself - testing is in progress.