### PR TITLE
Update VT Code ACP registry to 0.107.0

### DIFF
--- a/vtcode/agent.json
+++ b/vtcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "vtcode",
   "name": "VT Code",
-  "version": "0.96.14",
+  "version": "0.105.1",
   "description": "An open-source coding agent with LLM-native code understanding and robust shell safety. Supports multiple LLM providers with automatic failover and efficient context management.",
   "repository": "https://github.com/vinhnx/VTCode",
   "website": "https://github.com/vinhnx/VTCode/blob/main/docs/guides/zed-acp.md",
@@ -10,7 +10,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.105.1/vtcode-0.105.1-aarch64-apple-darwin.tar.gz",
         "cmd": "./vtcode",
         "args": ["acp"],
         "env": {
@@ -19,7 +19,7 @@
         }
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.105.1/vtcode-0.105.1-x86_64-apple-darwin.tar.gz",
         "cmd": "./vtcode",
         "args": ["acp"],
         "env": {
@@ -28,7 +28,7 @@
         }
       },
       "linux-x86_64": {
-        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.105.1/vtcode-0.105.1-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./vtcode",
         "args": ["acp"],
         "env": {

--- a/vtcode/agent.json
+++ b/vtcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "vtcode",
   "name": "VT Code",
-  "version": "0.105.1",
+  "version": "0.107.0",
   "description": "An open-source coding agent with LLM-native code understanding and robust shell safety. Supports multiple LLM providers with automatic failover and efficient context management.",
   "repository": "https://github.com/vinhnx/VTCode",
   "website": "https://github.com/vinhnx/VTCode/blob/main/docs/guides/zed-acp.md",
@@ -10,7 +10,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.105.1/vtcode-0.105.1-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.107.0/vtcode-0.107.0-aarch64-apple-darwin.tar.gz",
         "cmd": "./vtcode",
         "args": ["acp"],
         "env": {
@@ -19,7 +19,7 @@
         }
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.105.1/vtcode-0.105.1-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.107.0/vtcode-0.107.0-x86_64-apple-darwin.tar.gz",
         "cmd": "./vtcode",
         "args": ["acp"],
         "env": {
@@ -28,7 +28,7 @@
         }
       },
       "linux-x86_64": {
-        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.105.1/vtcode-0.105.1-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.107.0/vtcode-0.107.0-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./vtcode",
         "args": ["acp"],
         "env": {
@@ -37,7 +37,7 @@
         }
       },
       "windows-x86_64": {
-        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/vinhnx/VTCode/releases/download/0.107.0/vtcode-0.107.0-x86_64-pc-windows-msvc.zip",
         "cmd": "vtcode.exe",
         "args": ["acp"],
         "env": {


### PR DESCRIPTION
Follow-up to #266 that refreshes VT Code to the latest release and points the Windows binary at the 0.107.0 build artifact. The one-off Windows-enabled release workflow has been dispatched so the asset URL is valid for reviewers and downstream clients.