### PR TITLE
Update junie/agent.json to version 1755.50 with updated distribution links

### DIFF
--- a/junie/agent.json
+++ b/junie/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "junie",
   "name": "Junie",
-  "version": "1668.43.0",
+  "version": "1755.50",
   "description": "AI Coding Agent by JetBrains",
   "repository": "https://github.com/JetBrains/junie",
   "website": "https://junie.jetbrains.com",
@@ -10,27 +10,27 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1668.43/junie-release-1668.43-macos-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1755.50/junie-release-1755.50-macos-aarch64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1668.43/junie-release-1668.43-macos-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1755.50/junie-release-1755.50-macos-amd64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1668.43/junie-release-1668.43-linux-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1755.50/junie-release-1755.50-linux-aarch64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1668.43/junie-release-1668.43-linux-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1755.50/junie-release-1755.50-linux-amd64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1668.43/junie-release-1668.43-windows-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1755.50/junie-release-1755.50-windows-amd64.zip",
         "cmd": "./junie/junie.exe",
         "args": ["--acp=true"]
       }


### PR DESCRIPTION
Update links for Junie to latest stable release