### PR TITLE
Add acp-bridge: ACP/A2A adapter for self-hosted local AI

### DIFF
--- a/acp-bridge/agent.json
+++ b/acp-bridge/agent.json
@@ -5,7 +5,7 @@
   "description": "ACP/A2A adapter for self-hosted AI — bridges local LLM backends (Ollama, vLLM, llama.cpp, LM Studio, LocalAI, Jan, Tabby) to the Agent Client Protocol so air-gapped or on-prem models can be used from ACP clients (Zed, Neovim, etc.).",
   "repository": "https://github.com/BlakeHung/acp-bridge",
   "website": "https://github.com/BlakeHung/acp-bridge",
-  "authors": ["WCHungBlake <mars7823482@gmail.com>"],
+  "authors": ["Blake Labs"],
   "license": "MIT",
   "distribution": {
     "binary": {

--- a/acp-bridge/agent.json
+++ b/acp-bridge/agent.json
@@ -1,0 +1,30 @@
+{
+  "id": "acp-bridge",
+  "name": "ACP Bridge",
+  "version": "0.7.0",
+  "description": "ACP/A2A adapter for self-hosted AI — bridges local LLM backends (Ollama, vLLM, llama.cpp, LM Studio, LocalAI, Jan, Tabby) to the Agent Client Protocol so air-gapped or on-prem models can be used from ACP clients (Zed, Neovim, etc.).",
+  "repository": "https://github.com/BlakeHung/acp-bridge",
+  "website": "https://github.com/BlakeHung/acp-bridge",
+  "authors": ["WCHungBlake <mars7823482@gmail.com>"],
+  "license": "MIT",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/BlakeHung/acp-bridge/releases/download/v0.7.0/acp-bridge-darwin-arm64",
+        "cmd": "./acp-bridge-darwin-arm64"
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/BlakeHung/acp-bridge/releases/download/v0.7.0/acp-bridge-darwin-amd64",
+        "cmd": "./acp-bridge-darwin-amd64"
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/BlakeHung/acp-bridge/releases/download/v0.7.0/acp-bridge-linux-arm64",
+        "cmd": "./acp-bridge-linux-arm64"
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/BlakeHung/acp-bridge/releases/download/v0.7.0/acp-bridge-linux-amd64",
+        "cmd": "./acp-bridge-linux-amd64"
+      }
+    }
+  }
+}

--- a/acp-bridge/icon.svg
+++ b/acp-bridge/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 12 V9 a6 5 0 0 1 12 0 V12"/>
+  <path d="M1 13 H15"/>
+  <path d="M8 9 V13"/>
+</svg>


### PR DESCRIPTION
Adds **acp-bridge** to the registry — a Rust adapter that bridges local LLM backends (Ollama, vLLM, llama.cpp, LM Studio, LocalAI, Jan, Tabby) to the Agent Client Protocol, so air-gapped or on-prem models can be used from ACP clients like Zed and Neovim.

## v0.7.0 highlights

- **ACP server mode** (default) — exposes a local LLM as an ACP-compliant agent over stdin/stdout JSON-RPC 2.0.
- **ACP client mode** (`--client`) — also works as an orchestrator that spawns other ACP agents as child processes.
- **A2A mode** (`--a2a`) — HTTP server exposing an Agent Card at `/.well-known/agent.json`.
- **Spec-compliance fixes** — `initialize` returns top-level `protocolVersion: 1`, `agentCapabilities.promptCapabilities.image: true`, and `authMethods: []`; `session/new` accepts `mcpServers` (previously silently dropped).
- Process group isolation, content blocks, session/load resume support, env-var expansion for child agents.

Release: https://github.com/BlakeHung/acp-bridge/releases/tag/v0.7.0

## Distribution

Raw binary downloads from the v0.7.0 GitHub release for four platforms:
- darwin-aarch64, darwin-x86_64, linux-aarch64, linux-x86_64

Windows builds are not yet produced by the release workflow; will be added in a follow-up.

## Checklist

- [x] `id` matches directory name (`acp-bridge`)
- [x] `agent.json` valid against schema
- [x] `icon.svg` is 16x16, monochrome, uses `currentColor`
- [x] All four `archive` URLs return 200
- [x] License is OSI (MIT)