### PR TITLE
feat: add workweaver agent

### DIFF
--- a/workweaver/agent.json
+++ b/workweaver/agent.json
@@ -1,0 +1,21 @@
+{
+  "id": "workweaver",
+  "name": "Workweaver",
+  "version": "0.1.11",
+  "description": "AI workforce for business operations. Mount the open-source Workweaver CLI into any ACP-compatible editor (Zed, JetBrains, VS Code ACP Client extension) and drive missions, edge connectors, WorkMemory recall, browser automation, and edge inference through the canonical session/prompt surface.",
+  "repository": "https://github.com/bitfoundry-ai/workweaver",
+  "website": "https://workweaver.ai",
+  "authors": [
+    "Workweaver <hello@workweaver.ai>"
+  ],
+  "license": "AGPL-3.0-or-later",
+  "distribution": {
+    "uvx": {
+      "package": "workweaver==0.1.11",
+      "args": [
+        "acp",
+        "start"
+      ]
+    }
+  }
+}

--- a/workweaver/agent.json
+++ b/workweaver/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "workweaver",
   "name": "Workweaver",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "AI workforce for business operations. Mount the open-source Workweaver CLI into any ACP-compatible editor (Zed, JetBrains, VS Code ACP Client extension) and drive missions, edge connectors, WorkMemory recall, browser automation, and edge inference through the canonical session/prompt surface.",
   "repository": "https://github.com/bitfoundry-ai/workweaver",
   "website": "https://workweaver.ai",
@@ -11,7 +11,7 @@
   "license": "AGPL-3.0-or-later",
   "distribution": {
     "uvx": {
-      "package": "workweaver==0.1.11",
+      "package": "workweaver",
       "args": [
         "acp",
         "start"

--- a/workweaver/icon.svg
+++ b/workweaver/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M2 3h12v2H2zM2 7h12v2H2zM2 11h12v2H2zM4 1v1H3v1H2V1zm9 0v1h1v1h1V1zM4 14v1H3v-1H2v2h2v-1zm9 1v-1h1v1h1v-2h-2v1z"/>
+</svg>


### PR DESCRIPTION
Adds the **Workweaver** agent to the registry.

Workweaver is an open-source AI workforce for business operations. Its CLI exposes a canonical ACP agent over stdio (`uvx workweaver acp start`) — drive missions, edge connectors, WorkMemory recall, browser automation, and edge inference through the canonical session/prompt surface in any ACP-compatible editor (Zed, JetBrains, VS Code ACP client).

- Repository: https://github.com/bitfoundry-ai/workweaver
- Distribution: `uvx workweaver==0.1.11 acp start`
- Auth method: `workweaver-cli-context` (`type: agent`), reusing the active Workweaver CLI auth context.

Validated locally against this repo's tooling:
- `SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py` → builds with `workweaver` included.
- `python3 .github/workflows/verify_agents.py --auth-check --agent workweaver` → **All tests passed** (auth-method present on `initialize`).

Refs https://github.com/bitfoundry-ai/workweaver/issues/4338