### PR TITLE
[codex] Quarantine crow-cli 0.1.25 auto-update

### DIFF
--- a/quarantine.json
+++ b/quarantine.json
@@ -1,5 +1,6 @@
 {
   "agoragentic-acp": "Postinstall script",
+  "crow-cli": "ACP initialize fails in crow-cli 0.1.25",
   "deepagents": "Missing npm dependency",
   "junie": "Auto-update disabled",
   "minion-code": "Python dependency issue",


### PR DESCRIPTION
## Summary

- Quarantine `crow-cli` from automated version updates.
- Keep the currently registered `crow-cli` version unchanged in registry output.

## Root Cause

The hourly `Update Agent Versions` workflow tries to update `crow-cli` from `0.1.24` to `0.1.25`. The `0.1.25` Linux binary exits before ACP initialize because it attempts to open `$HOME/.crow/logs/crow-cli.log` in the isolated auth sandbox before creating the parent directory. That makes `verify-updates` report an initialize timeout.

## Validation

- `uv run .github/workflows/update_versions.py --agents crow-cli --json`
- `uv run .github/workflows/update_versions.py --json`
- `uv run --with jsonschema .github/workflows/build_registry.py --dry-run`
- `cd .github/workflows && uv run --with pytest pytest tests/test_registry_utils.py tests/test_update_versions.py -v`
- `git diff --check`
