### PR TITLE
Update junie/agent.json to version 1892.26.0 with updated distribution links

### DIFF
--- a/junie/agent.json
+++ b/junie/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "junie",
   "name": "Junie",
-  "version": "1831.35.0",
+  "version": "1892.26.0",
   "description": "AI Coding Agent by JetBrains",
   "repository": "https://github.com/JetBrains/junie",
   "website": "https://junie.jetbrains.com",
@@ -10,27 +10,27 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1831.35/junie-release-1831.35-macos-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-macos-aarch64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1831.35/junie-release-1831.35-macos-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-macos-amd64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1831.35/junie-release-1831.35-linux-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-linux-aarch64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1831.35/junie-release-1831.35-linux-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-linux-amd64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1831.35/junie-release-1831.35-windows-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/1892.26/junie-release-1892.26-windows-amd64.zip",
         "cmd": "./junie/junie.exe",
         "args": ["--acp=true"]
       }


### PR DESCRIPTION
Bumps the Junie agent entry to release `1892.26` (version field `1892.26.0`).

- Updates `version` from `1831.35.0` to `1892.26.0`.
- Updates all binary distribution `archive` URLs to the `1892.26` release tag.

`1892.26` is the latest non-nightly (stable) Junie release ("Junie Release 26.6.8 (1892.26)"). All archive URLs verified to return HTTP 200 and `junie/agent.json` validates against `agent.schema.json`.