### PR TITLE
Add codehalter agent v25

### DIFF
--- a/codehalter/agent.json
+++ b/codehalter/agent.json
@@ -1,0 +1,37 @@
+{
+  "id": "codehalter",
+  "name": "codehalter",
+  "version": "25.0.0",
+  "description": "ACP-only coding agent that runs in a devcontainer sandbox against any OpenAI-compatible LLM (llama.cpp, Ollama, vLLM, ...)",
+  "repository": "https://github.com/tbocek/codehalter",
+  "license": "MIT",
+  "icon": "./icon.svg",
+  "authors": [
+    "Thomas Bocek"
+  ],
+  "website": "https://tbocek.github.io/codehalter/",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/tbocek/codehalter/releases/download/v25/codehalter-darwin-arm64",
+        "cmd": "./codehalter-darwin-arm64"
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/tbocek/codehalter/releases/download/v25/codehalter-darwin-amd64",
+        "cmd": "./codehalter-darwin-amd64"
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/tbocek/codehalter/releases/download/v25/codehalter-linux-arm64",
+        "cmd": "./codehalter-linux-arm64"
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/tbocek/codehalter/releases/download/v25/codehalter-linux-amd64",
+        "cmd": "./codehalter-linux-amd64"
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/tbocek/codehalter/releases/download/v25/codehalter-windows-amd64.exe",
+        "cmd": "./codehalter-windows-amd64.exe"
+      }
+    }
+  }
+}

--- a/codehalter/icon.svg
+++ b/codehalter/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 256 256" fill="none">
+  <g stroke="currentColor" stroke-width="15" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M82 64 H56 V192 H82"/>
+    <path d="M174 64 H200 V192 H174"/>
+  </g>
+  <rect x="120" y="86" width="16" height="84" rx="5" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
codehalter is an ACP coding agent that connects to any OpenAI-compatible model, built for and focused on local LLMs. It has no UI of its own: your editor is the front end, not a CLI. Plan → execute → verify → document, all through the ACP bridge