### PR TITLE
Update devin to 2026.7.16

### DIFF
--- a/devin/agent.json
+++ b/devin/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "devin",
   "name": "Devin",
-  "version": "2026.5.26",
+  "version": "2026.7.16",
   "description": "Devin CLI coding agent by Cognition",
   "website": "https://docs.devin.ai/cli",
   "authors": ["Cognition"],
@@ -9,32 +9,32 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-aarch64-apple-darwin.tar.gz",
+        "archive": "https://static.devin.ai/cli/2026.7.16/devin-2026.7.16-aarch64-apple-darwin.tar.gz",
         "cmd": "./bin/devin",
         "args": ["acp"]
       },
       "darwin-x86_64": {
-        "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-x86_64-apple-darwin.tar.gz",
+        "archive": "https://static.devin.ai/cli/2026.7.16/devin-2026.7.16-x86_64-apple-darwin.tar.gz",
         "cmd": "./bin/devin",
         "args": ["acp"]
       },
       "linux-aarch64": {
-        "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-aarch64-unknown-linux.tar.gz",
+        "archive": "https://static.devin.ai/cli/2026.7.16/devin-2026.7.16-aarch64-unknown-linux.tar.gz",
         "cmd": "./bin/devin",
         "args": ["acp"]
       },
       "linux-x86_64": {
-        "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-x86_64-unknown-linux.tar.gz",
+        "archive": "https://static.devin.ai/cli/2026.7.16/devin-2026.7.16-x86_64-unknown-linux.tar.gz",
         "cmd": "./bin/devin",
         "args": ["acp"]
       },
       "windows-aarch64": {
-        "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-aarch64-pc-windows.zip",
+        "archive": "https://static.devin.ai/cli/2026.7.16/devin-2026.7.16-aarch64-pc-windows.zip",
         "cmd": "./bin\\devin.exe",
         "args": ["acp"]
       },
       "windows-x86_64": {
-        "archive": "https://static.devin.ai/cli/2026.5.26-8/devin-2026.5.26-8-x86_64-pc-windows.zip",
+        "archive": "https://static.devin.ai/cli/2026.7.16/devin-2026.7.16-x86_64-pc-windows.zip",
         "cmd": "./bin\\devin.exe",
         "args": ["acp"]
       }


### PR DESCRIPTION
## Summary
- Bumped devin version from 2026.5.26 to 2026.7.16
- Updated all binary distribution URLs to match new release

#### Test plan
- [x] Build validation passes
- [x] URLs are accessible and match manifest

Generated with [Devin](https://devin.ai)