### PR TITLE
Update github-copilot version to 1.508.0

### DIFF
--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.507.0",
+  "version": "1.508.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.507.0",
+      "package": "@github/copilot-language-server@1.508.0",
       "args": [
         "--acp"
       ]


### PR DESCRIPTION
Earlier PR: https://github.com/agentclientprotocol/registry/pull/377 bump to 1.507.0 to minimize the impacted users.

This 1.508.0 version to recover configuration files.