### PR TITLE
Quarantine codebuddy-code: npx executable missing

### DIFF
--- a/quarantine.json
+++ b/quarantine.json
@@ -1,5 +1,6 @@
 {
   "agoragentic-acp": "Postinstall script",
+  "codebuddy-code": "npx cannot determine executable to run",
   "crow-cli": "ACP initialize fails in crow-cli 0.1.25",
   "deepagents": "Missing npm dependency",
   "junie": "Auto-update disabled",


### PR DESCRIPTION
## Summary
- Quarantine `codebuddy-code` agent — its npx package doesn't expose a proper executable, causing `npm error could not determine executable to run` and failing all `Update Agent Versions` CI runs since at least 2026-06-17.

## Test plan
- [x] `build_registry.py --dry-run` passes
- [ ] CI `verify-updates` job should pass without codebuddy-code

🤖 Generated with [Claude Code](https://claude.com/claude-code)