### PR TITLE
Update junie/agent.json to version 2045.5.0 with updated distribution links

### DIFF
--- a/junie/agent.json
+++ b/junie/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "junie",
   "name": "Junie",
-  "version": "1966.53.0",
+  "version": "2045.5.0",
   "description": "AI Coding Agent by JetBrains",
   "repository": "https://github.com/JetBrains/junie",
   "website": "https://junie.jetbrains.com",
@@ -10,27 +10,27 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1966.53/junie-release-1966.53-macos-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2045.5/junie-eap-2045.5-macos-aarch64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1966.53/junie-release-1966.53-macos-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2045.5/junie-eap-2045.5-macos-amd64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1966.53/junie-release-1966.53-linux-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2045.5/junie-eap-2045.5-linux-aarch64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1966.53/junie-release-1966.53-linux-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2045.5/junie-eap-2045.5-linux-amd64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/1966.53/junie-release-1966.53-windows-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2045.5/junie-eap-2045.5-windows-amd64.zip",
         "cmd": "./junie/junie.exe",
         "args": ["--acp=true"]
       }


### PR DESCRIPTION
Bumps the Junie agent entry to release `2045.5` (version field `2045.5.0`).

- Updates `version` from `1966.53.0` to `2045.5.0`.
- Updates all binary distribution `archive` URLs to the `2045.5` release tag (note the `junie-eap-` asset prefix).

`2045.5` ("Junie EAP 26.6.22 (2045.5)") is the latest non-nightly Junie release. All archive URLs verified to return HTTP 200 and `junie/agent.json` validates against `agent.schema.json`.