### PR TITLE
Add kiro-agent-acp

### DIFF
--- a/kiro-agent-acp/agent.json
+++ b/kiro-agent-acp/agent.json
@@ -1,0 +1,16 @@
+{
+  "id": "kiro-agent-acp",
+  "name": "Kiro",
+  "version": "0.1.0",
+  "description": "ACP adapter for Kiro CLI with model, agent, and thinking level selection",
+  "repository": "https://github.com/todouu/kiro-agent-acp",
+  "authors": ["todouu"],
+  "license": "Apache-2.0",
+  "icon": "icon.svg",
+  "distribution": {
+    "npx": {
+      "package": "kiro-agent-acp@latest",
+      "args": []
+    }
+  }
+}

--- a/kiro-agent-acp/icon.svg
+++ b/kiro-agent-acp/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M3 2L3 14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M3 8L10 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M3 8L10 14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M11 6L11 14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Adds Kiro CLI ACP adapter with model/agent/thinking selection.

- Distribution: npx (kiro-agent-acp@latest)
- License: Apache-2.0
- Repository: https://github.com/todouu/kiro-agent-acp