### PR TITLE
Add CodeWhale ACP agent

### DIFF
--- a/codewhale/agent.json
+++ b/codewhale/agent.json
@@ -1,0 +1,21 @@
+{
+  "id": "codewhale",
+  "name": "CodeWhale",
+  "version": "0.8.65",
+  "description": "Provider-agnostic terminal coding agent with first-class DeepSeek support.",
+  "repository": "https://github.com/Hmbown/CodeWhale",
+  "website": "https://github.com/Hmbown/CodeWhale/blob/main/docs/RUNTIME_API.md#acp-stdio-adapter-codewhale-serve---acp",
+  "authors": [
+    "Hunter Bown"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "codewhale@0.8.65",
+      "args": [
+        "serve",
+        "--acp"
+      ]
+    }
+  }
+}

--- a/codewhale/icon.svg
+++ b/codewhale/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M2 9.5c0-3.3 2.7-6 6-6h4.5v2H8a4 4 0 0 0-4 4v.5h7.5a2.5 2.5 0 0 0 2.4-1.8l.6-2.2H16l-.7 2.7A4 4 0 0 1 11.5 12H4.2A3 3 0 0 1 2 9.5Z" fill="currentColor"/>
+  <path d="M5 7h1.5v1.5H5V7Zm3 0h1.5v1.5H8V7Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
Adds CodeWhale to the ACP registry.\n\nCodeWhale is a provider-agnostic terminal coding agent with first-class DeepSeek support. The submitted distribution uses the published npm package and runs `codewhale serve --acp`.\n\nLocal readiness checked in Hmbown/CodeWhale:\n- ACP stdio adapter exists at `codewhale serve --acp`.\n- Published `codewhale@0.8.65` returns terminal auth via `auth set --provider <provider>` from `initialize`.\n- `session/new`, `session/prompt`, `session/cancel`, and streamed `session/update` chunks are implemented.\n- The adapter is intentionally baseline: no ACP shell/file tools, no session loading, and no full runtime API through ACP.\n\nValidation run locally against this registry checkout:\n- `python3 .github/workflows/verify_agents.py --auth-check --agent codewhale --verbose` -> passed: `Auth OK: codewhale-terminal-auth(terminal)`\n- `uv run --with jsonschema .github/workflows/build_registry.py` -> passed and added `codewhale v0.8.65` to the generated registry\n\nCloses #302.