### PR TITLE
Add SuperQode ACP agent

### DIFF
--- a/superqode/README.md
+++ b/superqode/README.md
@@ -1,0 +1,37 @@
+# SuperQode
+
+SuperQode is a harness engineering coding agent, optimized for local and open
+models. Unlike agents with a fixed loop, the loop SuperQode runs is a
+**HarnessSpec**: a portable YAML contract in your repository that controls
+model routing, tools, memory, sandbox, approvals, and checks — and that you
+can version, measure with eval scorecards, and optimize.
+
+## How sessions resolve their harness
+
+Each ACP session picks its HarnessSpec from the project you have open:
+
+1. `superqode.local.yaml` in the session directory
+2. `harness.yaml` in the session directory
+3. Specs under `.superqode/harness/` (and other conventional harness dirs)
+4. The built-in coding template as a fallback
+
+## Model configuration
+
+The provider and model come from the spec's `model_policy.primary`
+(for example `ollama/qwen3-coder`), or from the environment:
+
+```bash
+SUPERQODE_ACP_PROVIDER=ollama
+SUPERQODE_ACP_MODEL=qwen3-coder
+```
+
+Run the "Set up SuperQode" authentication step to detect your hardware,
+pick a local model, and generate a starter harness for the project
+(`superqode local init --repo .`). Hosted/BYOK providers work through the
+same spec with your usual provider API keys.
+
+## Links
+
+- [Documentation](https://superagenticai.github.io/superqode/)
+- [Harness engineering guide](https://superagenticai.github.io/superqode/harness-engineering/)
+- [Source](https://github.com/SuperagenticAI/superqode)

--- a/superqode/agent.json
+++ b/superqode/agent.json
@@ -1,0 +1,21 @@
+{
+  "id": "superqode",
+  "name": "SuperQode",
+  "version": "0.2.4",
+  "description": "Harness engineering coding agent for local and open models. The agent loop is a versioned HarnessSpec in your repository: model routing, tools, approvals, sandbox, and evals you can measure and optimize.",
+  "repository": "https://github.com/SuperagenticAI/superqode",
+  "website": "https://super-agentic.ai/superqode",
+  "authors": [
+    "Superagentic AI"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "uvx": {
+      "package": "superqode==0.2.4",
+      "args": [
+        "serve",
+        "acp"
+      ]
+    }
+  }
+}

--- a/superqode/agent.json
+++ b/superqode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "superqode",
   "name": "SuperQode",
-  "version": "0.2.4",
+  "version": "0.2.7",
   "description": "Harness engineering coding agent for local and open models. The agent loop is a versioned HarnessSpec in your repository: model routing, tools, approvals, sandbox, and evals you can measure and optimize.",
   "repository": "https://github.com/SuperagenticAI/superqode",
   "website": "https://super-agentic.ai/superqode",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "uvx": {
-      "package": "superqode==0.2.4",
+      "package": "superqode==0.2.7",
       "args": [
         "serve",
         "acp"

--- a/superqode/icon.svg
+++ b/superqode/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M10 1.75H3A1.25 1.25 0 0 0 1.75 3v10A1.25 1.25 0 0 0 3 14.25h10A1.25 1.25 0 0 0 14.25 13V6.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="4.6" cy="4.6" r="0.65" fill="currentColor"/>
+  <circle cx="6.6" cy="4.6" r="0.65" fill="currentColor"/>
+  <circle cx="8.6" cy="4.6" r="0.65" fill="currentColor"/>
+  <path d="M4.5 7.25 7 9.5 4.5 11.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8.75 11.75h2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="11.5" y="3.5" width="2" height="2" rx="0.3" fill="currentColor"/>
+  <rect x="13.9" y="1" width="2" height="2" rx="0.3" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## Add SuperQode

[SuperQode](https://github.com/SuperagenticAI/superqode) is a harness engineering coding agent, optimized for local and open models. The agent loop is a versioned HarnessSpec — a YAML contract in the user's repository controlling model routing, tools, sandbox, approvals, and eval checks — resolved per session from the project the client opens (`superqode.local.yaml`, `harness.yaml`, or a built-in coding template).

### Details

- **Distribution:** uvx, `superqode==0.2.4` (PyPI), entry point `serve acp`
- **License:** Apache-2.0
- **Authentication:** terminal auth (`superqode local init --repo .`) — an interactive setup that detects local hardware, selects a local model, and generates a starter harness for the project
- **Docs:** https://superagenticai.github.io/superqode/

### Validation performed

- `uv run --with jsonschema .github/workflows/build_registry.py` passes with this agent included (39 agents, URL checks enabled)
- Cold install verified: `uvx superqode==0.2.4 serve acp` completes the ACP `initialize` handshake and returns an `authMethods` array containing a terminal auth method
- Full prompt turn verified end-to-end against a local Ollama model from an ACP client over stdio: streamed agent message chunks, thought chunks, tool call updates, permission requests for tool approvals, and `session/cancel` handling
- Icon is 16×16 SVG, monochrome `currentColor` only