### PR TITLE
Add nolotus-omp agent

### DIFF
--- a/nolotus-omp/agent.json
+++ b/nolotus-omp/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "nolotus-omp",
+  "name": "Oh My Pi (nolotus)",
+  "version": "16.3.6",
+  "description": "ACP adapter for Oh My Pi (oh-my-pi / omp), a batteries-included terminal AI coding agent. Published as a registry entry that delegates to the official @oh-my-pi/pi-coding-agent npm package's `omp acp` subcommand.",
+  "repository": "https://github.com/can1357/oh-my-pi",
+  "website": "https://omp.sh",
+  "authors": [
+    "nolotus <nolotus@users.noreply.github.com>",
+    "Can Bölük <can.boluk89@gmail.com>"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "@oh-my-pi/pi-coding-agent@16.3.6",
+      "args": ["acp"],
+      "env": {}
+    }
+  }
+}

--- a/nolotus-omp/icon.svg
+++ b/nolotus-omp/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <circle cx="8" cy="8" r="6.25" stroke="currentColor" stroke-width="1.25"/>
+  <circle cx="8" cy="8" r="2.5" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
Adds **nolotus-omp**, an ACP registry entry that delegates to the official `@oh-my-pi/pi-coding-agent` npm package's `omp acp` subcommand.

**Rationale**: the upstream oh-my-pi project (by can1357) does not currently ship a registry entry, so this provides a discoverable installation path for Zed (via `zed: acp registry`) and JetBrains users without forking the agent itself.

**Verified locally**:
- `uv run .github/workflows/build_registry.py` passes schema validation
- ACP `initialize` handshake against `omp acp` returns valid `authMethods` (type=agent)
- Icon is 16x16 monochrome using `currentColor`

Distribution: npx only, pinning `@oh-my-pi/pi-coding-agent@16.3.6` (current stable).

Sister project / brand: personal entry, distinct from the upstream oh-my-pi name. Happy to rename or merge into a different entry if maintainers prefer a unified id.