### PR TITLE
Add Bodega One Code

### DIFF
--- a/bodega-one-code/agent.json
+++ b/bodega-one-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "bodega-one-code",
   "name": "Bodega One Code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local-first AI coding agent — runs fully offline against local models (Ollama, llama.cpp) or BYOK cloud providers, with a hard air-gap mode and verified edits",
   "repository": "https://github.com/BodegaoneAI/bodegaone-cli-releases",
   "website": "https://bodegaone.ai",
@@ -10,27 +10,27 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-darwin-arm64.tar.gz",
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.1/bodega-darwin-arm64.tar.gz",
         "cmd": "./bin/bodega",
         "args": ["serve", "--acp"]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-darwin-amd64.tar.gz",
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.1/bodega-darwin-amd64.tar.gz",
         "cmd": "./bin/bodega",
         "args": ["serve", "--acp"]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-linux-arm64.tar.gz",
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.1/bodega-linux-arm64.tar.gz",
         "cmd": "./bin/bodega",
         "args": ["serve", "--acp"]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-linux-amd64.tar.gz",
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.1/bodega-linux-amd64.tar.gz",
         "cmd": "./bin/bodega",
         "args": ["serve", "--acp"]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-windows-amd64.zip",
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.1/bodega-windows-amd64.zip",
         "cmd": "bin/bodega.exe",
         "args": ["serve", "--acp"]
       }

--- a/bodega-one-code/agent.json
+++ b/bodega-one-code/agent.json
@@ -1,0 +1,39 @@
+{
+  "id": "bodega-one-code",
+  "name": "Bodega One Code",
+  "version": "0.1.0",
+  "description": "Local-first AI coding agent — runs fully offline against local models (Ollama, llama.cpp) or BYOK cloud providers, with a hard air-gap mode and verified edits",
+  "repository": "https://github.com/BodegaoneAI/bodegaone-cli-releases",
+  "website": "https://bodegaone.ai",
+  "authors": ["Bodega One"],
+  "license": "proprietary",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-darwin-arm64.tar.gz",
+        "cmd": "./bin/bodega",
+        "args": ["serve", "--acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-darwin-amd64.tar.gz",
+        "cmd": "./bin/bodega",
+        "args": ["serve", "--acp"]
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-linux-arm64.tar.gz",
+        "cmd": "./bin/bodega",
+        "args": ["serve", "--acp"]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-linux-amd64.tar.gz",
+        "cmd": "./bin/bodega",
+        "args": ["serve", "--acp"]
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/download/v0.1.0/bodega-windows-amd64.zip",
+        "cmd": "bin/bodega.exe",
+        "args": ["serve", "--acp"]
+      }
+    }
+  }
+}

--- a/bodega-one-code/icon.svg
+++ b/bodega-one-code/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" fill-rule="evenodd" d="M3 1h7v2h2v1h1v3h-1v1h-1v1h1v1h1v3h-1v1h-2v2H3V1zm3 3v3h4V4H6zm0 6v3h4v-3H6z"/>
+</svg>


### PR DESCRIPTION
Adds **Bodega One Code** — the terminal surface of [Bodega One](https://bodegaone.ai): a local-first AI coding agent (TUI + headless) for macOS/Linux/Windows that runs fully offline against local models (Ollama, llama.cpp) or BYOK cloud providers, with a hard air-gap mode and verified edits.

- ACP entry point: `bodega serve --acp` (JSON-RPC over stdio; the bundle carries its own Node runtime and backend — no prerequisites)
- Binary distribution for all five platforms from the public releases repo; versions there follow `v*` tags
- Icon: 16×16 monochrome `currentColor` SVG

**A note on the authentication requirement:** Bodega One Code is local-first and requires no account — its ACP `initialize` response advertises an explicit `authMethods: []` (there is nothing to authenticate; sessions work immediately against local models, and cloud keys are user-managed app config rather than an ACP auth flow). We read AUTHENTICATION.md as targeting agents that need credentials to function; if the registry requires a declared auth method even for no-auth agents, we're happy to adapt — guidance welcome.

Disclosure: this submission was prepared with AI assistance, reviewed and approved by the Bodega One maintainers.