### PR TITLE
Update junie/agent.json to version 2144.9.0 with updated distribution links

### DIFF
--- a/junie/agent.json
+++ b/junie/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "junie",
   "name": "Junie",
-  "version": "2144.7.0",
+  "version": "2144.9.0",
   "description": "AI Coding Agent by JetBrains",
   "repository": "https://github.com/JetBrains/junie",
   "website": "https://junie.jetbrains.com",
@@ -10,27 +10,27 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-macos-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-macos-aarch64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-macos-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-macos-amd64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": ["--acp=true"]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-linux-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-linux-aarch64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-linux-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-linux-amd64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": ["--acp=true"]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2144.7/junie-release-2144.7-windows-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-windows-amd64.zip",
         "cmd": "./junie/junie.exe",
         "args": ["--acp=true"]
       }


### PR DESCRIPTION
Bumps the Junie agent entry to the latest stable release 2144.9 (version field 2144.9.0).

version: 2144.7.0 → 2144.9.0
all archive distribution URLs updated to the 2144.9 release
2144.9 is the newest stable Junie Release. All archive URLs are verified to return HTTP 200, and junie/agent.json validates against agent.schema.json