### PR TITLE
Add Hermes Agent to ACP Registry

### DIFF
--- a/hermes-agent/agent.json
+++ b/hermes-agent/agent.json
@@ -1,0 +1,36 @@
+{
+  "id": "hermes-agent",
+  "name": "Hermes Agent",
+  "version": "0.18.2",
+  "description": "Nous Research's personal AI agent — memory, skills, browser, web, multi-agent delegation. ACP adapter for Zed, VS Code, JetBrains.",
+  "repository": "https://github.com/NousResearch/hermes-agent",
+  "website": "https://hermes-agent.nousresearch.com/docs",
+  "authors": [
+    "Nous Research"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "binary": {
+      "linux-aarch64": {
+        "archive": "https://github.com/gad0n3/hermes-acp-launcher/releases/download/v0.1.0/hermes-acp-launcher.tar.gz",
+        "cmd": "./hermes-acp",
+        "args": ["acp"]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/gad0n3/hermes-acp-launcher/releases/download/v0.1.0/hermes-acp-launcher.tar.gz",
+        "cmd": "./hermes-acp",
+        "args": ["acp"]
+      },
+      "darwin-aarch64": {
+        "archive": "https://github.com/gad0n3/hermes-acp-launcher/releases/download/v0.1.0/hermes-acp-launcher.tar.gz",
+        "cmd": "./hermes-acp",
+        "args": ["acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/gad0n3/hermes-acp-launcher/releases/download/v0.1.0/hermes-acp-launcher.tar.gz",
+        "cmd": "./hermes-acp",
+        "args": ["acp"]
+      }
+    }
+  }
+}

--- a/hermes-agent/icon.svg
+++ b/hermes-agent/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8B5CF6"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+  <rect width="16" height="16" rx="3" fill="url(#g)"/>
+  <path d="M3 4v8l5-4-5-4zm10 0l-5 4 5 4V4z" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8 8l2.5 2m0-4L8 8" fill="none" stroke="#fff" stroke-width="0.8" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Hermes Agent — ACP Registry Entry

[Hermes Agent](https://github.com/NousResearch/hermes-agent) by [Nous Research](https://nousresearch.com/) — a personal AI agent with cross-session memory, reusable skills, browser automation, web search, multi-agent delegation, and cron scheduling.

### Features
- 🧠 **Cross-session memory** — remembers preferences across conversations
- 🔧 **Reusable skills** — saved workflows for repeatable tasks
- 🌐 **Browser + web** — full browser automation and web search
- 📋 **Multi-agent delegation** — spawn sub-agents for parallel work
- 🖥️ **Local models** — Ollama support for offline-first inference
- ⏰ **Cron scheduling** — autonomous recurring jobs

### Distribution
Minimal shell launcher that runs `hermes acp`.  
Launcher repo: https://github.com/gad0n3/hermes-acp-launcher  
Requires Hermes Agent to be installed: https://hermes-agent.nousresearch.com/docs

### Verification
```bash
# Verify the launcher
curl -sL https://github.com/gad0n3/hermes-acp-launcher/releases/download/v0.1.0/hermes-acp-launcher.tar.gz | tar xz
cat hermes-acp  # should be a shell script running 'exec hermes acp'
```

Closes #none