### PR TITLE
Add Zed Native LM Studio Agent

### DIFF
--- a/zed-lm-studio-agent/agent.json
+++ b/zed-lm-studio-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "zed-lm-studio-agent",
   "name": "Zed Native LM Studio Agent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A local-first ACP coding agent for Zed powered by LM Studio.",
   "repository": "https://github.com/99percentgrip/Native-LM-Studio-ACP",
   "website": "https://github.com/99percentgrip/Native-LM-Studio-ACP",
@@ -12,15 +12,15 @@
   "distribution": {
     "binary": {
       "darwin-x86_64": {
-        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.0/zed-lm-studio-agent-darwin-x86_64.tar.gz",
+        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.1/zed-lm-studio-agent-darwin-x86_64.tar.gz",
         "cmd": "./zed-lm-studio-agent"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.0/zed-lm-studio-agent-linux-x86_64.tar.gz",
+        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.1/zed-lm-studio-agent-linux-x86_64.tar.gz",
         "cmd": "./zed-lm-studio-agent"
       },
       "windows-x86_64": {
-        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.0/zed-lm-studio-agent-windows-x86_64.zip",
+        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.1/zed-lm-studio-agent-windows-x86_64.zip",
         "cmd": "./zed-lm-studio-agent.exe"
       }
     }

--- a/zed-lm-studio-agent/agent.json
+++ b/zed-lm-studio-agent/agent.json
@@ -1,0 +1,28 @@
+{
+  "id": "zed-lm-studio-agent",
+  "name": "Zed Native LM Studio Agent",
+  "version": "1.0.0",
+  "description": "A local-first ACP coding agent for Zed powered by LM Studio.",
+  "repository": "https://github.com/99percentgrip/Native-LM-Studio-ACP",
+  "website": "https://github.com/99percentgrip/Native-LM-Studio-ACP",
+  "authors": [
+    "Aleksejs Kozlitins"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "binary": {
+      "darwin-x86_64": {
+        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.0/zed-lm-studio-agent-darwin-x86_64.tar.gz",
+        "cmd": "./zed-lm-studio-agent"
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.0/zed-lm-studio-agent-linux-x86_64.tar.gz",
+        "cmd": "./zed-lm-studio-agent"
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/99percentgrip/Native-LM-Studio-ACP/releases/download/v1.0.0/zed-lm-studio-agent-windows-x86_64.zip",
+        "cmd": "./zed-lm-studio-agent.exe"
+      }
+    }
+  }
+}

--- a/zed-lm-studio-agent/icon.svg
+++ b/zed-lm-studio-agent/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <rect x="2.5" y="2.5" width="11" height="11" rx="2" stroke="currentColor"/>
+  <path d="M5 10.5V5.5L8 8.5L11 5.5V10.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## What changed

Adds `zed-lm-studio-agent` v1.0.1 to the ACP Registry with Linux, macOS, and Windows x86-64 binary distributions and the required monochrome 16×16 icon.

## Why

Zed Native LM Studio Agent is a local-first ACP coding agent that connects Zed to OpenAI-compatible LM Studio servers. It supports native ACP sessions, tools, planning, MCP servers, model selection, context management, and Registry-compatible Terminal Auth.

## Authentication

The agent advertises `lm-studio-setup` with `type: terminal`. The setup flow verifies the configured LM Studio endpoint and stores optional API tokens in the operating-system credential manager rather than plaintext configuration.

## Validation

- `uv run --with jsonschema .github/workflows/build_registry.py --dry-run`
- `uv run --with agent-client-protocol .github/workflows/verify_agents.py --auth-check --agent zed-lm-studio-agent`
- Official verifier result: `Auth OK: lm-studio-setup(terminal)`
- All three release archive URLs are public and version-pinned to `v1.0.1`.
- Project CI passes on Linux, macOS, and Windows for release commit `f395a94`.
