### PR TITLE
feat: add gptme agent

### DIFF
--- a/gptme/agent.json
+++ b/gptme/agent.json
@@ -1,0 +1,18 @@
+{
+  "id": "gptme",
+  "name": "gptme",
+  "version": "0.33.0",
+  "description": "Powerful AI agent for coding and general tasks. Terminal-first with shell, code execution, file editing, web browsing, vision, and computer use.",
+  "repository": "https://github.com/gptme/gptme",
+  "website": "https://gptme.org",
+  "authors": [
+    "Erik Bjäreholt"
+  ],
+  "license": "MIT",
+  "license_url": "https://github.com/gptme/gptme/blob/master/LICENSE",
+  "distribution": {
+    "uvx": {
+      "package": "gptme-acp"
+    }
+  }
+}

--- a/gptme/icon.svg
+++ b/gptme/icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" role="img" aria-label="gptme">
+  <title>gptme</title>
+  <!-- Helmet + ear pods, with the face plate cut out (even-odd) -->
+  <path fill="currentColor" fill-rule="evenodd" d="
+    M16,5.6 a11,11 0 1,0 0,22 a11,11 0 1,0 0,-22 Z
+    M7.2,17.2
+    C7.2,12.1 8.9,9.7 11.3,9.7
+    C13.3,9.7 15.0,10.6 16,11.5
+    C17.0,10.6 18.7,9.7 20.7,9.7
+    C23.1,9.7 24.8,12.1 24.8,17.2
+    C24.8,21.5 21.2,23.8 16,23.8
+    C10.8,23.8 7.2,21.5 7.2,17.2 Z"/>
+  <circle cx="3.0" cy="16.8" r="2.15" fill="currentColor"/>
+  <circle cx="29.0" cy="16.8" r="2.15" fill="currentColor"/>
+  <!-- Eyes and smile sit inside the cut-out face -->
+  <circle cx="12.1" cy="16.3" r="2.35" fill="currentColor"/>
+  <circle cx="19.9" cy="16.3" r="2.35" fill="currentColor"/>
+  <path d="M14.1,19.8 Q16,21.6 17.9,19.8" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/gptme/icon.svg
+++ b/gptme/icon.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" role="img" aria-label="gptme">
   <title>gptme</title>
-  <!-- Helmet + ear pods, with the face plate cut out (even-odd) -->
   <path fill="currentColor" fill-rule="evenodd" d="
     M16,5.6 a11,11 0 1,0 0,22 a11,11 0 1,0 0,-22 Z
     M7.2,17.2
@@ -12,7 +11,6 @@
     C10.8,23.8 7.2,21.5 7.2,17.2 Z"/>
   <circle cx="3.0" cy="16.8" r="2.15" fill="currentColor"/>
   <circle cx="29.0" cy="16.8" r="2.15" fill="currentColor"/>
-  <!-- Eyes and smile sit inside the cut-out face -->
   <circle cx="12.1" cy="16.3" r="2.35" fill="currentColor"/>
   <circle cx="19.9" cy="16.3" r="2.35" fill="currentColor"/>
   <path d="M14.1,19.8 Q16,21.6 17.9,19.8" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>


### PR DESCRIPTION
## Summary

Adds [gptme](https://gptme.org) to the ACP agent registry.

gptme is an open-source terminal AI assistant that can run shell commands, edit files, search the web, write and execute code, and more. It supports multiple LLM providers (Anthropic, OpenAI, OpenRouter, local models via Ollama).

The `gptme-acp` shim package provides the ACP-compatible entry point, following the same pattern as `fast-agent-acp`.

## Entry

```json
{
  "id": "gptme",
  "name": "gptme",
  "version": "0.33.0",
  "description": "Powerful AI agent for coding and general tasks. Terminal-first with shell, code execution, file editing, web browsing, vision, and computer use.",
  "repository": "https://github.com/gptme/gptme",
  "website": "https://gptme.org",
  "authors": ["Erik Bjäreholt"],
  "license": "MIT",
  "license_url": "https://github.com/gptme/gptme/blob/master/LICENSE",
  "distribution": {
    "uvx": {
      "package": "gptme-acp"
    }
  }
}
```

## Verified

- `gptme-acp==0.33.0` is on PyPI: https://pypi.org/project/gptme-acp/0.33.0/
- ACP `initialize` returns non-empty `authMethods` (gptme#3274, shipped in v0.32.1)
- Official 16×16 `currentColor` icon from gptme#3583 (`media/icon-mono.svg`)
- `uvx gptme-acp` launches the ACP server

## CI

The `Build Registry` check is waiting on maintainer approval (fork PR). Latest run: https://github.com/agentclientprotocol/registry/actions/runs/33535785561 (`action_required`).

## Links

- PyPI: https://pypi.org/project/gptme-acp/
- Repo: https://github.com/gptme/gptme
- Website: https://gptme.org
- Docs: https://gptme.org/docs/acp.html
- Release: https://github.com/gptme/gptme/releases/tag/v0.33.0
