### PR TITLE
Add codebuff-acp

### DIFF
--- a/codebuff-acp/agent.json
+++ b/codebuff-acp/agent.json
@@ -1,0 +1,14 @@
+{
+  "id": "codebuff-acp",
+  "name": "Codebuff Agent",
+  "version": "0.1.1",
+  "description": "ACP wrapper for Codebuff's agent engine",
+  "repository": "https://github.com/dvaJi/codebuff-agent-acp",
+  "authors": ["Francisco Pizarro"],
+  "license": "Apache-2.0",
+  "distribution": {
+    "npx": {
+      "package": "codebuff-agent-acp@0.1.1"
+    }
+  }
+}

--- a/codebuff-acp/icon.svg
+++ b/codebuff-acp/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
+  <path fill="currentColor" fill-rule="evenodd" d="M3 2a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3Zm0 2h10v8H3V4Z" clip-rule="evenodd"/>
+  <path fill="currentColor" d="m6.25 5 .46 1.29L8 6.75l-1.29.46L6.25 8.5l-.46-1.29L4.5 6.75l1.29-.46L6.25 5ZM8.5 9h3v1h-3z"/>
+</svg>


### PR DESCRIPTION
Adds [codebuff-acp](https://github.com/dvaJi/codebuff-agent-acp) — an unofficial
ACP adapter for the Codebuff agent engine, distributed on npm as
[`codebuff-agent-acp`](https://www.npmjs.com/package/codebuff-agent-acp).

- **npm**: `codebuff-agent-acp@0.1.1` (published with provenance)
- **auth**: `terminal` — `--setup` collects the Codebuff API key and saves it
  locally (`~/.codebuff-acp/config.json`)
- **icon**: 16×16 monochrome, `currentColor`
- **license**: Apache-2.0

> Unofficial / community project — not affiliated with, endorsed by, or
> sponsored by Codebuff, Inc.

Validation:

- [x] `agent.json` matches the schema
- [x] `icon.svg` is 16×16, monochrome (`currentColor` / `none` only)
- [x] npm package exists; version `0.1.1` matches the pinned distribution
- [x] `initialize` advertises a `terminal` auth method (`--setup`)
