### PR TITLE
Remove Junie Agent from quarantine and update agent.json with new repository path and Windows AArch64 support

### DIFF
--- a/junie/agent.json
+++ b/junie/agent.json
@@ -3,7 +3,7 @@
   "name": "Junie",
   "version": "2383.9.0",
   "description": "AI Coding Agent by JetBrains",
-  "repository": "https://github.com/JetBrains/junie",
+  "repository": "https://github.com/JetBrains/junie-acp-release",
   "website": "https://junie.jetbrains.com",
   "authors": ["JetBrains"],
   "license": "proprietary",
@@ -31,6 +31,11 @@
       },
       "windows-x86_64": {
         "archive": "https://github.com/JetBrains/junie/releases/download/2383.9/junie-release-2383.9-windows-amd64.zip",
+        "cmd": "./junie/junie.exe",
+        "args": ["--acp=true"]
+      },
+      "windows-aarch64": {
+        "archive": "https://github.com/JetBrains/junie/releases/download/2383.9/junie-release-2383.9-windows-aarch64.zip",
         "cmd": "./junie/junie.exe",
         "args": ["--acp=true"]
       }

--- a/quarantine.json
+++ b/quarantine.json
@@ -3,7 +3,6 @@
   "codebuddy-code": "npx cannot determine executable to run",
   "crow-cli": "ACP initialize fails in crow-cli 0.1.25",
   "deepagents": "Missing npm dependency",
-  "junie": "Auto-update disabled",
   "minion-code": "Python dependency issue",
   "qoder": "ACP initialize fails in qodercli 0.2.15/0.2.16",
   "vtcode": "Missing windows builds"


### PR DESCRIPTION
This PR re-enables automatic version updates for **junie** and makes the entry self-sustaining, so no further manual PRs are needed after merge

Added also `windows-aarch64` publication refence