### PR TITLE
Point CLAUDE.md at AGENTS.md with a symlink

### DIFF
--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Ruff check
         working-directory: .github/workflows
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/daily-protocol-matrix.yml
+++ b/.github/workflows/daily-protocol-matrix.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -146,7 +146,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Apply version updates
         env:
@@ -325,7 +325,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Validate registry build
         run: uv run --with jsonschema .github/workflows/build_registry.py
@@ -415,7 +415,7 @@ jobs:
           PY
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Validate registry build
         run: uv run --with jsonschema .github/workflows/build_registry.py

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -83,45 +83,11 @@ jobs:
     needs: check-versions
     if: failure()
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
-      - name: Create failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const title = `Version check failed - ${new Date().toISOString().split('T')[0]}`;
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-
-            // Check if issue already exists today
-            const existingIssues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'version-check-failure',
-              per_page: 10
-            });
-
-            const todayIssue = existingIssues.data.find(i => i.title === title);
-            if (todayIssue) {
-              // Add comment to existing issue
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: todayIssue.number,
-                body: `Another failure occurred.\n\n**Run:** ${runUrl}`
-              });
-            } else {
-              // Create new issue
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: `The automated version check workflow failed.\n\n**Run:** ${runUrl}\n\nPlease investigate the failure.`,
-                labels: ['version-check-failure', 'automated']
-              });
-            }
+      - name: Summarize failure
+        run: |
+          echo '## Version check failed' >> "$GITHUB_STEP_SUMMARY"
+          echo "[Open this workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." >> "$GITHUB_STEP_SUMMARY"
 
   apply-updates:
     needs: check-versions
@@ -354,7 +320,8 @@ jobs:
       cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      actions: write
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -474,65 +441,25 @@ jobs:
           git commit -m "$COMMIT_SUMMARY" -m "$COMMIT_DETAILS"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
-      # Generating a GitHub token, so that commits created by the
-      # action can trigger the registry publication workflow.
-      - name: Generate GitHub token
-        if: steps.commit.outputs.committed == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        id: generate-token
-        with:
-          # GitHub App ID secret name
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
-          # GitHub App private key secret name
-          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
-
       - name: Push updates to main
         if: steps.commit.outputs.committed == 'true'
         env:
-          GH_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_APP_TOKEN" | base64 | tr -d '\n')"
-          echo "::add-mask::$AUTH_HEADER"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" push origin main
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+
+      - name: Publish updated registry
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run build-registry.yml --ref main
 
   notify-apply-failure:
     needs: [check-versions, apply-updates, verify-updates, commit-updates]
     if: always() && (needs.apply-updates.result == 'failure' || needs.verify-updates.result == 'failure' || needs.commit-updates.result == 'failure')
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
-      - name: Create failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const title = `Version update failed - ${new Date().toISOString().split('T')[0]}`;
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-
-            // Check if issue already exists today
-            const existingIssues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'version-update-failure',
-              per_page: 10
-            });
-
-            const todayIssue = existingIssues.data.find(i => i.title === title);
-            if (todayIssue) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: todayIssue.number,
-                body: `Another failure occurred.\n\n**Run:** ${runUrl}`
-              });
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: `The automated version update workflow failed while applying updates.\n\nThis could be due to:\n- Registry validation failure\n- Auth verification failure\n- Git push conflict\n- Network issues\n\n**Run:** ${runUrl}\n\nPlease investigate.`,
-                labels: ['version-update-failure', 'automated']
-              });
-            }
+      - name: Summarize failure
+        run: |
+          echo '## Version update failed' >> "$GITHUB_STEP_SUMMARY"
+          echo "[Open this workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,178 +1,69 @@
-# AGENTS.md
+# Agent guidance
 
-This file provides guidance to AI coding agents when working with code in this repository.
+This repository publishes the Agent Client Protocol registry. Each top-level
+agent directory contains an `agent.json` manifest and a 16 by 16 monochrome
+`icon.svg`. Treat `agent.schema.json` and the validation scripts as the
+authoritative format contract.
 
-## Build Commands
+## Validate changes
 
-```bash
-# Build registry (validates all agents and outputs to dist/)
-uv run --with jsonschema .github/workflows/build_registry.py
+Run the narrow checks first, then the complete workflow suite:
 
-# Dry run (validate without writing to dist/)
+```sh
 uv run --with jsonschema .github/workflows/build_registry.py --dry-run
-
-# Build without schema validation (if jsonschema not available)
-python .github/workflows/build_registry.py
+cd .github/workflows
+uv run --with ruff ruff check .
+uv run --with ruff ruff format --check .
+uv run --with pytest pytest tests/ -v
 ```
 
-## Testing & Linting
+The Docker wrapper reproduces CI dependencies and architecture more closely:
 
-```bash
-# Run workflow tests in the Dockerized local environment (recommended)
+```sh
 .github/workflows/scripts/run-workflows-tests.sh
-
-# Run workflow tests natively on the host (CI-style debugging only)
-cd .github/workflows && uv run --with pytest pytest tests/ -v
-
-# Lint check
-cd .github/workflows && uv run --with ruff ruff check .
-
-# Format check
-cd .github/workflows && uv run --with ruff ruff format --check .
-
-# Auto-fix formatting
-cd .github/workflows && uv run --with ruff ruff format .
+.github/workflows/scripts/run-registry-docker.sh \
+  uv run --with jsonschema .github/workflows/build_registry.py
 ```
 
-## Docker Validation
+Use `.github/workflows/scripts/run-protocol-matrix.sh` only when agent runtime
+or authentication behavior changes. It creates isolated state by default.
+Set `ACP_PROTOCOL_MATRIX_KEEP_STATE=1` only for intentional debugging.
 
-GitHub Actions runs the nightly protocol matrix natively on the runner (`uv` + Node.js installed in the workflow), but local verification can still use Docker to keep downloads, caches, and auth-related state isolated from your host machine:
+## Update versions
 
-```bash
-# Run workflow tests in the Dockerized local environment
-.github/workflows/scripts/run-workflows-tests.sh
+Use the updater instead of editing distribution URLs independently:
 
-# Validate schema/build output in a container
-.github/workflows/scripts/run-registry-docker.sh uv run --with jsonschema .github/workflows/build_registry.py
-
-# Verify registered agents in a container
-.github/workflows/scripts/run-registry-docker.sh python3 .github/workflows/verify_agents.py --auth-check
-
-# Generate the protocol feature matrix in a container
-.github/workflows/scripts/run-protocol-matrix.sh
-
-# Generate a capabilities-only matrix table in a container
-.github/workflows/scripts/run-protocol-matrix.sh --table-mode capabilities
-
-# Reuse unchanged agent versions from the previous snapshot
-.github/workflows/scripts/run-protocol-matrix.sh --table-mode capabilities --changed-only
+```sh
+uv run .github/workflows/update_versions.py --agents harn
+uv run .github/workflows/update_versions.py --apply --agents harn
+uv run --with jsonschema .github/workflows/build_registry.py --dry-run
 ```
 
-`run-protocol-matrix.sh` mirrors the scheduled GitHub Actions defaults: it uses `--table-mode capabilities` and creates ephemeral isolated Docker state plus a fresh protocol sandbox by default so agents cannot reuse local login/keychain state or stale install artifacts across runs. Set `ACP_PROTOCOL_MATRIX_KEEP_STATE=1` if you intentionally want to keep the container state and `.matrix-sandbox` for debugging.
+The scheduled workflow checks releases hourly. GitHub binary updates require a
+GitHub `repository` URL; npm and PyPI packages use their registries. Entries in
+`quarantine.json` are intentionally excluded until their recorded failure is
+resolved.
 
-The generic Docker wrapper keeps state under `.docker-state/` in the repo, defaults to `linux/amd64` to match `ubuntu-latest`, injects a passwd entry for the current UID inside the container, and disables Python keyring backends to avoid host keychain prompts during local verification. It reuses an existing local Docker image when the requested platform and image inputs still match, and rebuilds automatically when they do not; set `ACP_REGISTRY_BUILD_IMAGE=1` to force a rebuild. Treat the Docker wrappers as the canonical local path; use host-native `uv run ...` commands only when you intentionally want to debug outside the container. Set `ACP_REGISTRY_DOCKER_PLATFORM=` to opt out of the default platform override when you explicitly want native-architecture debugging.
-Set `ACP_PROTOCOL_MATRIX_SKIP_AGENTS=crow-cli` to skip specific agents during matrix generation.
+## Registry rules
 
-## Architecture
+- Directory names and manifest `id` values use lowercase letters, digits, and
+  hyphens and must match.
+- `version` uses semantic versioning.
+- Every manifest provides at least one `binary`, `npx`, or `uvx`
+  distribution.
+- Binary archives use a supported archive format or a raw executable. The
+  validator rejects installers such as DMG, PKG, DEB, RPM, MSI, and AppImage.
+- Icons are 16 by 16 SVGs using `currentColor`; do not add fixed colors.
+- Agents must return at least one `agent` or `terminal` authentication method
+  during ACP initialization. See [AUTHENTICATION.md](./AUTHENTICATION.md).
 
-This is a registry of ACP (Agent Client Protocol) agents. The structure is:
+Set `SKIP_URL_VALIDATION=1` only for an offline diagnostic run. Do not use it
+as evidence that a registry change is ready to merge.
 
-```
-<id>/
-├── agent.json      # Agent metadata and distribution info
-└── icon.svg        # Icon: 16x16 SVG, monochrome with currentColor (required)
-```
+## Publication
 
-**Build process** (`.github/workflows/build_registry.py`):
-
-1. Scans directories for `agent.json` files
-2. Validates against `agent.schema.json` (JSON Schema)
-3. Validates icons (16x16 SVG, monochrome with `currentColor`)
-4. Aggregates into `dist/registry.json`
-5. Copies icons to `dist/<id>.svg`
-
-**CI/CD** (`.github/workflows/build-registry.yml`):
-
-- PRs: Runs validation only
-- Push to main: Validates, then publishes versioned + `latest` GitHub releases
-
-## Validation Rules
-
-- `id`: lowercase, hyphens only, must match directory name
-- `version`: semantic versioning (e.g., `1.0.0`)
-- `distribution`: at least one of `binary`, `npx`, `uvx`
-- `binary` distribution: builds for all operating systems (darwin, linux, windows) are recommended; missing OS families produce a warning
-- `binary` archives must use supported formats (`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries); installer formats (`.dmg`, `.pkg`, `.deb`, `.rpm`, `.msi`, `.appimage`) are rejected
-- `icon.svg`: must be SVG format, 16x16, monochrome using `currentColor` (enables theming)
-- **URL validation**: All distribution URLs must be accessible (binary archives, npm/PyPI packages)
-
-Set `SKIP_URL_VALIDATION=1` to bypass URL checks during local development.
-
-## Updating Agent Versions
-
-### Automated Updates
-
-Agent versions are automatically updated via `.github/workflows/update-versions.yml`:
-
-- **Schedule:** Runs hourly (cron: `0 * * * *`)
-- **Scope:** Checks all agents in the root directory
-- **Supported distributions:** `npx` (npm), `uvx` (PyPI), `binary` (GitHub releases only — non-GitHub `repository` URLs are skipped)
-
-```bash
-# Dry run - check for available updates
-uv run .github/workflows/update_versions.py
-
-# Apply updates locally
-uv run .github/workflows/update_versions.py --apply
-
-# Check specific agents only
-uv run .github/workflows/update_versions.py --agents gemini,github-copilot
-```
-
-The workflow can also be triggered manually via GitHub Actions with options to apply updates and filter by agent IDs.
-
-### Manual Updates
-
-To update agents manually:
-
-1. **For npm packages** (`npx` distribution): Check latest version at `https://registry.npmjs.org/<package>/latest`
-2. **For GitHub binaries** (`binary` distribution): Check latest release at `https://api.github.com/repos/<owner>/<repo>/releases/latest`. Note: automated version checking only works for agents with a GitHub `repository` URL. Proprietary agents with non-GitHub or missing `repository` URLs must be updated manually.
-
-Update `agent.json`:
-
-- Update the `version` field
-- Update version in all distribution URLs (use replace-all for consistency)
-- For npm: update `package` field (e.g., `@google/gemini-cli@0.22.5`)
-- For binaries: update archive URLs with new version/tag
-
-Run build to validate: `uv run --with jsonschema .github/workflows/build_registry.py`
-
-## Distribution Types
-
-- `binary`: Platform-specific archives (`darwin-aarch64`, `linux-x86_64`, etc.). Supported archive formats: `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries. Supporting all operating systems (darwin, linux, windows) is recommended.
-- `npx`: npm packages (cross-platform by default)
-- `uvx`: PyPI packages (cross-platform by default)
-
-## Icon Requirements
-
-Icons must be:
-
-- **SVG format** (only `.svg` files accepted)
-- **16x16 dimensions** (via width/height attributes or viewBox)
-- **Monochrome using `currentColor`** - all fills and strokes must use `currentColor` or `none`
-
-Using `currentColor` enables icons to adapt to different themes (light/dark mode) automatically.
-
-**Valid example:**
-
-```svg
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="currentColor" d="M..."/>
-</svg>
-```
-
-**Invalid patterns:**
-
-- Hardcoded colors: `fill="#FF5500"`, `fill="red"`, `stroke="rgb(0,0,0)"`
-- Missing currentColor: `fill` or `stroke` without `currentColor`
-
-## Authentication Validation
-
-Agents must support ACP authentication. The CI verifies auth via `.github/workflows/verify_agents.py --auth-check`.
-
-**Requirements:**
-
-- Return `authMethods` array in `initialize` response
-- At least one method must have type `"agent"` or `"terminal"`
-
-See [AUTHENTICATION.md](AUTHENTICATION.md) for details on implementing auth methods.
+Pull requests validate the registry. Changes on `main` run
+`.github/workflows/build-registry.yml`, which publishes versioned and `latest`
+registry releases. The version updater stages only expected `agent.json`
+files, verifies them, pushes the commit, and explicitly dispatches the build
+workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](AGENTS.md).
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ACP Registry
+# ACP registry
 
 https://agentclientprotocol.com/registry
 
 Registry of agents implementing the [Agent Client Protocol, ACP](https://github.com/agentclientprotocol/agent-client-protocol).
 
-> **Authentication Required**: This registry maintains a curated list of **agents that support user authentication**.
+> **Authentication required**: This registry maintains a curated list of **agents that support user authentication**.
 >
 > Users must be able to authenticate themselves with agents to use them.
 > All agents are verified via CI to ensure they return valid `authMethods` in the ACP handshake.
@@ -18,15 +18,15 @@ Fetch the registry index:
 https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json
 ```
 
-## Registry Format
+## Registry format
 
 See [FORMAT.md](FORMAT.md) for the registry schema, distribution types, and platform targets.
 
-## Automatic Version Updates
+## Automatic version updates
 
 Agent versions are automatically updated via a cron job that runs hourly. It checks for new releases across all supported distribution types (npm, PyPI, GitHub releases) and commits updates directly to `main`.
 
-## Adding an Agent
+## Adding an agent
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions.
 

--- a/auggie/agent.json
+++ b/auggie/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "auggie",
   "name": "Auggie CLI",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Augment Code's powerful software agent, backed by industry-leading context engine",
   "repository": "https://github.com/augmentcode/auggie",
   "website": "https://www.augmentcode.com/",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "@augmentcode/auggie@0.32.0",
+      "package": "@augmentcode/auggie@0.33.0",
       "args": [
         "--acp"
       ],

--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-acp",
   "name": "Claude Agent",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "ACP wrapper for Anthropic's Claude",
   "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/claude-agent-acp@0.60.0"
+      "package": "@agentclientprotocol/claude-agent-acp@0.61.0"
     }
   }
 }

--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-acp",
   "name": "Claude Agent",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "ACP wrapper for Anthropic's Claude",
   "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/claude-agent-acp@0.59.0"
+      "package": "@agentclientprotocol/claude-agent-acp@0.60.0"
     }
   }
 }

--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-acp",
   "name": "Claude Agent",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "description": "ACP wrapper for Anthropic's Claude",
   "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/claude-agent-acp@0.58.1"
+      "package": "@agentclientprotocol/claude-agent-acp@0.59.0"
     }
   }
 }

--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-acp",
   "name": "Claude Agent",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "ACP wrapper for Anthropic's Claude",
   "repository": "https://github.com/agentclientprotocol/claude-agent-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/claude-agent-acp@0.61.0"
+      "package": "@agentclientprotocol/claude-agent-acp@0.62.0"
     }
   }
 }

--- a/cline/agent.json
+++ b/cline/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "cline",
   "name": "Cline",
-  "version": "3.0.41",
+  "version": "3.0.42",
   "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
   "repository": "https://github.com/cline/cline",
   "website": "https://cline.bot/cli",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "cline@3.0.41",
+      "package": "cline@3.0.42",
       "args": [
         "--acp"
       ]

--- a/cline/agent.json
+++ b/cline/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "cline",
   "name": "Cline",
-  "version": "3.0.42",
+  "version": "3.0.44",
   "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
   "repository": "https://github.com/cline/cline",
   "website": "https://cline.bot/cli",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "cline@3.0.42",
+      "package": "cline@3.0.44",
       "args": [
         "--acp"
       ]

--- a/cline/agent.json
+++ b/cline/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "cline",
   "name": "Cline",
-  "version": "3.0.44",
+  "version": "3.0.45",
   "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
   "repository": "https://github.com/cline/cline",
   "website": "https://cline.bot/cli",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "cline@3.0.44",
+      "package": "cline@3.0.45",
       "args": [
         "--acp"
       ]

--- a/cline/agent.json
+++ b/cline/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "cline",
   "name": "Cline",
-  "version": "3.0.45",
+  "version": "3.0.46",
   "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
   "repository": "https://github.com/cline/cline",
   "website": "https://cline.bot/cli",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "cline@3.0.45",
+      "package": "cline@3.0.46",
       "args": [
         "--acp"
       ]

--- a/cline/agent.json
+++ b/cline/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "cline",
   "name": "Cline",
-  "version": "3.0.39",
+  "version": "3.0.40",
   "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
   "repository": "https://github.com/cline/cline",
   "website": "https://cline.bot/cli",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "cline@3.0.39",
+      "package": "cline@3.0.40",
       "args": [
         "--acp"
       ]

--- a/cline/agent.json
+++ b/cline/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "cline",
   "name": "Cline",
-  "version": "3.0.40",
+  "version": "3.0.41",
   "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
   "repository": "https://github.com/cline/cline",
   "website": "https://cline.bot/cli",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "cline@3.0.40",
+      "package": "cline@3.0.41",
       "args": [
         "--acp"
       ]

--- a/codex-acp/agent.json
+++ b/codex-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-acp",
   "name": "Codex",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "ACP adapter for OpenAI's coding assistant",
   "repository": "https://github.com/agentclientprotocol/codex-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/codex-acp@1.1.4"
+      "package": "@agentclientprotocol/codex-acp@1.1.5"
     }
   }
 }

--- a/codex-acp/agent.json
+++ b/codex-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-acp",
   "name": "Codex",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "ACP adapter for OpenAI's coding assistant",
   "repository": "https://github.com/agentclientprotocol/codex-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/codex-acp@1.1.0"
+      "package": "@agentclientprotocol/codex-acp@1.1.2"
     }
   }
 }

--- a/codex-acp/agent.json
+++ b/codex-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-acp",
   "name": "Codex",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "description": "ACP adapter for OpenAI's coding assistant",
   "repository": "https://github.com/agentclientprotocol/codex-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/codex-acp@1.1.5"
+      "package": "@agentclientprotocol/codex-acp@1.1.7"
     }
   }
 }

--- a/codex-acp/agent.json
+++ b/codex-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-acp",
   "name": "Codex",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "ACP adapter for OpenAI's coding assistant",
   "repository": "https://github.com/agentclientprotocol/codex-acp",
   "authors": [
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@agentclientprotocol/codex-acp@1.1.2"
+      "package": "@agentclientprotocol/codex-acp@1.1.4"
     }
   }
 }

--- a/devin/agent.json
+++ b/devin/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "devin",
   "name": "Devin",
-  "version": "3000.1.27",
+  "version": "3000.2.17",
   "description": "Devin CLI coding agent by Cognition",
   "website": "https://docs.devin.ai/cli",
   "authors": [
@@ -12,42 +12,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-apple-darwin.tar.gz",
+        "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-apple-darwin.tar.gz",
         "cmd": "./bin/devin",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-apple-darwin.tar.gz",
+        "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-apple-darwin.tar.gz",
         "cmd": "./bin/devin",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-unknown-linux.tar.gz",
+        "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-unknown-linux.tar.gz",
         "cmd": "./bin/devin",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-unknown-linux.tar.gz",
+        "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-unknown-linux.tar.gz",
         "cmd": "./bin/devin",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-pc-windows.zip",
+        "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-pc-windows.zip",
         "cmd": "./bin\\devin.exe",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-pc-windows.zip",
+        "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-pc-windows.zip",
         "cmd": "./bin\\devin.exe",
         "args": [
           "acp"

--- a/dimcode/agent.json
+++ b/dimcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dimcode",
   "name": "DimCode",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "A coding agent that puts leading models at your command.",
   "website": "https://dimcode.dev/docs/acp.html",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "dimcode@0.2.35",
+      "package": "dimcode@0.2.36",
       "args": [
         "acp"
       ]

--- a/dimcode/agent.json
+++ b/dimcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dimcode",
   "name": "DimCode",
-  "version": "0.2.33",
+  "version": "0.2.35",
   "description": "A coding agent that puts leading models at your command.",
   "website": "https://dimcode.dev/docs/acp.html",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "dimcode@0.2.33",
+      "package": "dimcode@0.2.35",
       "args": [
         "acp"
       ]

--- a/dimcode/agent.json
+++ b/dimcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dimcode",
   "name": "DimCode",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "A coding agent that puts leading models at your command.",
   "website": "https://dimcode.dev/docs/acp.html",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "dimcode@0.2.30",
+      "package": "dimcode@0.2.31",
       "args": [
         "acp"
       ]

--- a/dimcode/agent.json
+++ b/dimcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dimcode",
   "name": "DimCode",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "A coding agent that puts leading models at your command.",
   "website": "https://dimcode.dev/docs/acp.html",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "dimcode@0.2.27",
+      "package": "dimcode@0.2.28",
       "args": [
         "acp"
       ]

--- a/dimcode/agent.json
+++ b/dimcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dimcode",
   "name": "DimCode",
-  "version": "0.2.25",
+  "version": "0.2.27",
   "description": "A coding agent that puts leading models at your command.",
   "website": "https://dimcode.dev/docs/acp.html",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "dimcode@0.2.25",
+      "package": "dimcode@0.2.27",
       "args": [
         "acp"
       ]

--- a/dimcode/agent.json
+++ b/dimcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dimcode",
   "name": "DimCode",
-  "version": "0.2.31",
+  "version": "0.2.33",
   "description": "A coding agent that puts leading models at your command.",
   "website": "https://dimcode.dev/docs/acp.html",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "dimcode@0.2.31",
+      "package": "dimcode@0.2.33",
       "args": [
         "acp"
       ]

--- a/dimcode/agent.json
+++ b/dimcode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dimcode",
   "name": "DimCode",
-  "version": "0.2.28",
+  "version": "0.2.30",
   "description": "A coding agent that puts leading models at your command.",
   "website": "https://dimcode.dev/docs/acp.html",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "dimcode@0.2.28",
+      "package": "dimcode@0.2.30",
       "args": [
         "acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.20",
+      "package": "dirac-cli@0.4.21",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.16",
+      "package": "dirac-cli@0.4.17",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.13",
+  "version": "0.4.15",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.13",
+      "package": "dirac-cli@0.4.15",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.17",
+      "package": "dirac-cli@0.4.18",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.19",
+      "package": "dirac-cli@0.4.20",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.15",
+      "package": "dirac-cli@0.4.16",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.18",
+      "package": "dirac-cli@0.4.19",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.21",
+      "package": "dirac-cli@0.4.22",
       "args": [
         "--acp"
       ]

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "dirac",
   "name": "Dirac",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
   "repository": "https://github.com/dirac-run/dirac",
   "website": "https://dirac.run",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "dirac-cli@0.4.22",
+      "package": "dirac-cli@0.4.23",
       "args": [
         "--acp"
       ]

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.178.0",
+  "version": "0.179.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.178.0",
+      "package": "droid@0.179.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.170.0",
+  "version": "0.171.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.170.0",
+      "package": "droid@0.171.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.173.0",
+  "version": "0.174.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.173.0",
+      "package": "droid@0.174.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.177.0",
+  "version": "0.178.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.177.0",
+      "package": "droid@0.178.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.172.0",
+  "version": "0.173.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.172.0",
+      "package": "droid@0.173.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.171.0",
+  "version": "0.172.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.171.0",
+      "package": "droid@0.172.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.168.2",
+  "version": "0.170.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.168.2",
+      "package": "droid@0.170.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.175.0",
+  "version": "0.175.1",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.175.0",
+      "package": "droid@0.175.1",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.176.0",
+  "version": "0.177.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.176.0",
+      "package": "droid@0.177.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.174.0",
+  "version": "0.175.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.174.0",
+      "package": "droid@0.175.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.175.1",
+  "version": "0.176.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.175.1",
+      "package": "droid@0.176.0",
       "args": [
         "exec",
         "--output-format",

--- a/factory-droid/agent.json
+++ b/factory-droid/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "factory-droid",
   "name": "Factory Droid",
-  "version": "0.179.0",
+  "version": "0.180.0",
   "description": "Factory Droid - AI coding agent powered by Factory AI",
   "website": "https://factory.ai/product/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "droid@0.179.0",
+      "package": "droid@0.180.0",
       "args": [
         "exec",
         "--output-format",

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.5",
+      "package": "fast-agent-acp==0.9.6",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.19",
+      "package": "fast-agent-acp==0.9.20",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.21",
+      "package": "fast-agent-acp==0.9.22",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.20",
+      "package": "fast-agent-acp==0.9.21",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.18",
+      "package": "fast-agent-acp==0.9.19",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.4",
+      "package": "fast-agent-acp==0.9.5",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.9",
+      "package": "fast-agent-acp==0.9.10",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.16",
+      "package": "fast-agent-acp==0.9.17",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.14",
+      "package": "fast-agent-acp==0.9.15",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.15",
+      "package": "fast-agent-acp==0.9.16",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.17",
+      "package": "fast-agent-acp==0.9.18",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.10",
+  "version": "0.9.13",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.10",
+      "package": "fast-agent-acp==0.9.13",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.13",
+      "package": "fast-agent-acp==0.9.14",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.6",
+      "package": "fast-agent-acp==0.9.7",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.7",
+  "version": "0.9.9",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.7",
+      "package": "fast-agent-acp==0.9.9",
       "args": [
         "-x"
       ]

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fast-agent",
   "name": "fast-agent",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "Code and build agents with comprehensive multi-provider support",
   "repository": "https://github.com/evalstate/fast-agent",
   "website": "https://fast-agent.ai",
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "distribution": {
     "uvx": {
-      "package": "fast-agent-acp==0.9.22",
+      "package": "fast-agent-acp==0.9.23",
       "args": [
         "-x"
       ]

--- a/gemini/agent.json
+++ b/gemini/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "gemini",
   "name": "Gemini CLI",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Google's official CLI for Gemini",
   "repository": "https://github.com/google-gemini/gemini-cli",
   "website": "https://geminicli.com",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@google/gemini-cli@0.51.0",
+      "package": "@google/gemini-cli@0.52.0",
       "args": [
         "--acp"
       ]

--- a/gemini/agent.json
+++ b/gemini/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "gemini",
   "name": "Gemini CLI",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Google's official CLI for Gemini",
   "repository": "https://github.com/google-gemini/gemini-cli",
   "website": "https://geminicli.com",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@google/gemini-cli@0.50.0",
+      "package": "@google/gemini-cli@0.51.0",
       "args": [
         "--acp"
       ]

--- a/github-copilot-cli/agent.json
+++ b/github-copilot-cli/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-cli",
   "name": "GitHub Copilot",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-cli",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot@1.0.72",
+      "package": "@github/copilot@1.0.73",
       "args": [
         "--acp"
       ]

--- a/github-copilot-cli/agent.json
+++ b/github-copilot-cli/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-cli",
   "name": "GitHub Copilot",
-  "version": "1.0.73",
+  "version": "1.0.74",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-cli",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot@1.0.73",
+      "package": "@github/copilot@1.0.74",
       "args": [
         "--acp"
       ]

--- a/github-copilot-cli/agent.json
+++ b/github-copilot-cli/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-cli",
   "name": "GitHub Copilot",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-cli",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot@1.0.69",
+      "package": "@github/copilot@1.0.70",
       "args": [
         "--acp"
       ]

--- a/github-copilot-cli/agent.json
+++ b/github-copilot-cli/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-cli",
   "name": "GitHub Copilot",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-cli",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot@1.0.70",
+      "package": "@github/copilot@1.0.71",
       "args": [
         "--acp"
       ]

--- a/github-copilot-cli/agent.json
+++ b/github-copilot-cli/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-cli",
   "name": "GitHub Copilot",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-cli",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot@1.0.71",
+      "package": "@github/copilot@1.0.72",
       "args": [
         "--acp"
       ]

--- a/github-copilot-cli/agent.json
+++ b/github-copilot-cli/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-cli",
   "name": "GitHub Copilot",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-cli",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot@1.0.74",
+      "package": "@github/copilot@1.0.75",
       "args": [
         "--acp"
       ]

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.525.0",
+  "version": "1.526.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.525.0",
+      "package": "@github/copilot-language-server@1.526.0",
       "args": [
         "--acp"
       ]

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.523.0",
+  "version": "1.524.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.523.0",
+      "package": "@github/copilot-language-server@1.524.0",
       "args": [
         "--acp"
       ]

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.519.0",
+  "version": "1.520.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.519.0",
+      "package": "@github/copilot-language-server@1.520.0",
       "args": [
         "--acp"
       ]

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.524.0",
+  "version": "1.525.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.524.0",
+      "package": "@github/copilot-language-server@1.525.0",
       "args": [
         "--acp"
       ]

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.521.0",
+  "version": "1.522.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.521.0",
+      "package": "@github/copilot-language-server@1.522.0",
       "args": [
         "--acp"
       ]

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.522.0",
+  "version": "1.523.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.522.0",
+      "package": "@github/copilot-language-server@1.523.0",
       "args": [
         "--acp"
       ]

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot",
   "name": "GitHub Copilot",
-  "version": "1.520.0",
+  "version": "1.521.0",
   "description": "GitHub's AI pair programmer",
   "repository": "https://github.com/github/copilot-language-server-release",
   "website": "https://github.com/features/copilot/cli/",
@@ -11,7 +11,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@github/copilot-language-server@1.520.0",
+      "package": "@github/copilot-language-server@1.521.0",
       "args": [
         "--acp"
       ]

--- a/glm-acp-agent/agent.json
+++ b/glm-acp-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "glm-acp-agent",
   "name": "GLM Agent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": [
@@ -11,7 +11,7 @@
   "icon": "icon.svg",
   "distribution": {
     "npx": {
-      "package": "glm-acp-agent@1.2.0"
+      "package": "glm-acp-agent@1.3.0"
     }
   }
 }

--- a/glm-acp-agent/agent.json
+++ b/glm-acp-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "glm-acp-agent",
   "name": "GLM Agent",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": [
@@ -11,7 +11,7 @@
   "icon": "icon.svg",
   "distribution": {
     "npx": {
-      "package": "glm-acp-agent@1.1.4"
+      "package": "glm-acp-agent@1.2.0"
     }
   }
 }

--- a/goose/agent.json
+++ b/goose/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "goose",
   "name": "goose",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "A local, extensible, open source AI agent that automates engineering tasks",
   "repository": "https://github.com/block/goose",
   "website": "https://block.github.io/goose/",
@@ -12,35 +12,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.41.0/goose-aarch64-apple-darwin.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-aarch64-apple-darwin.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.41.0/goose-x86_64-apple-darwin.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-x86_64-apple-darwin.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.41.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.41.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.41.0/goose-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-x86_64-pc-windows-msvc.zip",
         "cmd": "./goose-package\\goose.exe",
         "args": [
           "acp"

--- a/goose/agent.json
+++ b/goose/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "goose",
   "name": "goose",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "A local, extensible, open source AI agent that automates engineering tasks",
   "repository": "https://github.com/block/goose",
   "website": "https://block.github.io/goose/",
@@ -12,35 +12,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-aarch64-apple-darwin.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-aarch64-apple-darwin.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-x86_64-apple-darwin.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-apple-darwin.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.42.0/goose-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-pc-windows-msvc.zip",
         "cmd": "./goose-package\\goose.exe",
         "args": [
           "acp"

--- a/goose/agent.json
+++ b/goose/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "goose",
   "name": "goose",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "A local, extensible, open source AI agent that automates engineering tasks",
   "repository": "https://github.com/block/goose",
   "website": "https://block.github.io/goose/",
@@ -12,35 +12,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-aarch64-apple-darwin.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.44.0/goose-aarch64-apple-darwin.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-apple-darwin.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.44.0/goose-x86_64-apple-darwin.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.44.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+        "archive": "https://github.com/block/goose/releases/download/v1.44.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
         "cmd": "./goose",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/block/goose/releases/download/v1.43.0/goose-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/block/goose/releases/download/v1.44.0/goose-x86_64-pc-windows-msvc.zip",
         "cmd": "./goose-package\\goose.exe",
         "args": [
           "acp"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.105",
+  "version": "0.2.106",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.105",
+      "package": "@xai-official/grok@0.2.106",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.108",
+  "version": "0.2.109",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.108",
+      "package": "@xai-official/grok@0.2.109",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.104",
+  "version": "0.2.105",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.104",
+      "package": "@xai-official/grok@0.2.105",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.106",
+  "version": "0.2.107",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.106",
+      "package": "@xai-official/grok@0.2.107",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.101",
+      "package": "@xai-official/grok@0.2.102",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.102",
+      "package": "@xai-official/grok@0.2.103",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.109",
+  "version": "0.2.110",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.109",
+      "package": "@xai-official/grok@0.2.110",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.99",
+  "version": "0.2.100",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.99",
+      "package": "@xai-official/grok@0.2.100",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.103",
+  "version": "0.2.104",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.103",
+      "package": "@xai-official/grok@0.2.104",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.94",
+  "version": "0.2.98",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.94",
+      "package": "@xai-official/grok@0.2.98",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.98",
+  "version": "0.2.99",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.98",
+      "package": "@xai-official/grok@0.2.99",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.100",
+  "version": "0.2.101",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.100",
+      "package": "@xai-official/grok@0.2.101",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.110",
+      "package": "@xai-official/grok@0.2.111",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.107",
+  "version": "0.2.108",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.107",
+      "package": "@xai-official/grok@0.2.108",
       "args": [
         "agent",
         "stdio"

--- a/grok-build/agent.json
+++ b/grok-build/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "grok-build",
   "name": "Grok Build",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "xAI's coding agent and CLI",
   "website": "https://x.ai/cli",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "proprietary",
   "distribution": {
     "npx": {
-      "package": "@xai-official/grok@0.2.111",
+      "package": "@xai-official/grok@0.2.112",
       "args": [
         "agent",
         "stdio"

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.31",
+  "version": "0.10.33",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.34",
+  "version": "0.10.35",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.36",
+  "version": "0.10.37",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.29",
+  "version": "0.10.30",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.29/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.12/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.33",
+  "version": "0.10.34",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.26",
+  "version": "0.10.27",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.13/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.16/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.22",
+  "version": "0.10.23",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.22/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.14/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.15/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.35",
+  "version": "0.10.36",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.35/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.36/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.17/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.5",
+  "version": "0.10.11",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.5/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.5/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.5/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.5/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.5/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.11/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.25/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.26/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.20/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.21/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.18/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.19/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.30",
+  "version": "0.10.31",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.30/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.31/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.27",
+  "version": "0.10.28",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.27/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.28/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.38",
+  "version": "0.10.39",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.39/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.39/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.39/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.39/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.39/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.10.37",
+  "version": "0.10.38",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.37/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.38/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",

--- a/kilo/agent.json
+++ b/kilo/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kilo",
   "name": "Kilo",
-  "version": "7.4.9",
+  "version": "7.4.11",
   "description": "The open source coding agent",
   "repository": "https://github.com/Kilo-Org/kilocode",
   "website": "https://kilo.ai/",
@@ -13,35 +13,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-darwin-arm64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-darwin-arm64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-darwin-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-darwin-x64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-linux-arm64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-linux-arm64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-linux-x64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-linux-x64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-windows-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-windows-x64.zip",
         "cmd": "./kilo.exe",
         "args": [
           "acp"
@@ -49,7 +49,7 @@
       }
     },
     "npx": {
-      "package": "@kilocode/cli@7.4.9",
+      "package": "@kilocode/cli@7.4.11",
       "args": [
         "acp"
       ]

--- a/kilo/agent.json
+++ b/kilo/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kilo",
   "name": "Kilo",
-  "version": "7.4.7",
+  "version": "7.4.8",
   "description": "The open source coding agent",
   "repository": "https://github.com/Kilo-Org/kilocode",
   "website": "https://kilo.ai/",
@@ -13,35 +13,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-darwin-arm64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-darwin-arm64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-darwin-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-darwin-x64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-linux-arm64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-linux-arm64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-linux-x64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-linux-x64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-windows-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-windows-x64.zip",
         "cmd": "./kilo.exe",
         "args": [
           "acp"
@@ -49,7 +49,7 @@
       }
     },
     "npx": {
-      "package": "@kilocode/cli@7.4.7",
+      "package": "@kilocode/cli@7.4.8",
       "args": [
         "acp"
       ]

--- a/kilo/agent.json
+++ b/kilo/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kilo",
   "name": "Kilo",
-  "version": "7.4.5",
+  "version": "7.4.7",
   "description": "The open source coding agent",
   "repository": "https://github.com/Kilo-Org/kilocode",
   "website": "https://kilo.ai/",
@@ -13,35 +13,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.5/kilo-darwin-arm64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-darwin-arm64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.5/kilo-darwin-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-darwin-x64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.5/kilo-linux-arm64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-linux-arm64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.5/kilo-linux-x64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-linux-x64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.5/kilo-windows-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.7/kilo-windows-x64.zip",
         "cmd": "./kilo.exe",
         "args": [
           "acp"
@@ -49,7 +49,7 @@
       }
     },
     "npx": {
-      "package": "@kilocode/cli@7.4.5",
+      "package": "@kilocode/cli@7.4.7",
       "args": [
         "acp"
       ]

--- a/kilo/agent.json
+++ b/kilo/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kilo",
   "name": "Kilo",
-  "version": "7.4.8",
+  "version": "7.4.9",
   "description": "The open source coding agent",
   "repository": "https://github.com/Kilo-Org/kilocode",
   "website": "https://kilo.ai/",
@@ -13,35 +13,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-darwin-arm64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-darwin-arm64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-darwin-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-darwin-x64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-linux-arm64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-linux-arm64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-linux-x64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-linux-x64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.8/kilo-windows-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.9/kilo-windows-x64.zip",
         "cmd": "./kilo.exe",
         "args": [
           "acp"
@@ -49,7 +49,7 @@
       }
     },
     "npx": {
-      "package": "@kilocode/cli@7.4.8",
+      "package": "@kilocode/cli@7.4.9",
       "args": [
         "acp"
       ]

--- a/kilo/agent.json
+++ b/kilo/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kilo",
   "name": "Kilo",
-  "version": "7.4.11",
+  "version": "7.4.15",
   "description": "The open source coding agent",
   "repository": "https://github.com/Kilo-Org/kilocode",
   "website": "https://kilo.ai/",
@@ -13,35 +13,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-darwin-arm64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-darwin-arm64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-darwin-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-darwin-x64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-linux-arm64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-linux-arm64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-linux-x64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-linux-x64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.11/kilo-windows-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-windows-x64.zip",
         "cmd": "./kilo.exe",
         "args": [
           "acp"
@@ -49,7 +49,7 @@
       }
     },
     "npx": {
-      "package": "@kilocode/cli@7.4.11",
+      "package": "@kilocode/cli@7.4.15",
       "args": [
         "acp"
       ]

--- a/kilo/agent.json
+++ b/kilo/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kilo",
   "name": "Kilo",
-  "version": "7.4.15",
+  "version": "7.4.16",
   "description": "The open source coding agent",
   "repository": "https://github.com/Kilo-Org/kilocode",
   "website": "https://kilo.ai/",
@@ -13,35 +13,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-darwin-arm64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.16/kilo-darwin-arm64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-darwin-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.16/kilo-darwin-x64.zip",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-linux-arm64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.16/kilo-linux-arm64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-linux-x64.tar.gz",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.16/kilo-linux-x64.tar.gz",
         "cmd": "./kilo",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.15/kilo-windows-x64.zip",
+        "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.16/kilo-windows-x64.zip",
         "cmd": "./kilo.exe",
         "args": [
           "acp"
@@ -49,7 +49,7 @@
       }
     },
     "npx": {
-      "package": "@kilocode/cli@7.4.15",
+      "package": "@kilocode/cli@7.4.16",
       "args": [
         "acp"
       ]

--- a/kimi/agent.json
+++ b/kimi/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kimi",
   "name": "Kimi CLI",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Moonshot AI's coding assistant",
   "repository": "https://github.com/MoonshotAI/kimi-cli",
   "website": "https://moonshotai.github.io/kimi-cli/",
@@ -12,35 +12,35 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.48.0/kimi-1.48.0-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-apple-darwin.tar.gz",
         "cmd": "./kimi",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.48.0/kimi-1.48.0-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./kimi",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.48.0/kimi-1.48.0-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./kimi",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.48.0/kimi-1.48.0-aarch64-pc-windows-msvc.zip",
+        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-pc-windows-msvc.zip",
         "cmd": "./kimi.exe",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.48.0/kimi-1.48.0-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-pc-windows-msvc.zip",
         "cmd": "./kimi.exe",
         "args": [
           "acp"

--- a/mistral-vibe/agent.json
+++ b/mistral-vibe/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "mistral-vibe",
   "name": "Mistral Vibe",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Mistral's open-source coding assistant",
   "repository": "https://github.com/mistralai/mistral-vibe",
   "website": "https://mistral.ai/products/vibe",
@@ -13,23 +13,23 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-darwin-aarch64-2.21.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-darwin-aarch64-2.22.0.zip",
         "cmd": "./vibe-acp"
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-darwin-x86_64-2.21.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-darwin-x86_64-2.22.0.zip",
         "cmd": "./vibe-acp"
       },
       "linux-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-linux-aarch64-2.21.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-linux-aarch64-2.22.0.zip",
         "cmd": "./vibe-acp"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-linux-x86_64-2.21.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-linux-x86_64-2.22.0.zip",
         "cmd": "./vibe-acp"
       },
       "windows-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-windows-x86_64-2.21.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-windows-x86_64-2.22.0.zip",
         "cmd": "./vibe-acp.exe"
       }
     }

--- a/mistral-vibe/agent.json
+++ b/mistral-vibe/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "mistral-vibe",
   "name": "Mistral Vibe",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "description": "Mistral's open-source coding assistant",
   "repository": "https://github.com/mistralai/mistral-vibe",
   "website": "https://mistral.ai/products/vibe",
@@ -13,23 +13,23 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.19.1/vibe-acp-darwin-aarch64-2.19.1.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-darwin-aarch64-2.20.0.zip",
         "cmd": "./vibe-acp"
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.19.1/vibe-acp-darwin-x86_64-2.19.1.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-darwin-x86_64-2.20.0.zip",
         "cmd": "./vibe-acp"
       },
       "linux-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.19.1/vibe-acp-linux-aarch64-2.19.1.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-linux-aarch64-2.20.0.zip",
         "cmd": "./vibe-acp"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.19.1/vibe-acp-linux-x86_64-2.19.1.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-linux-x86_64-2.20.0.zip",
         "cmd": "./vibe-acp"
       },
       "windows-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.19.1/vibe-acp-windows-x86_64-2.19.1.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-windows-x86_64-2.20.0.zip",
         "cmd": "./vibe-acp.exe"
       }
     }

--- a/mistral-vibe/agent.json
+++ b/mistral-vibe/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "mistral-vibe",
   "name": "Mistral Vibe",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "Mistral's open-source coding assistant",
   "repository": "https://github.com/mistralai/mistral-vibe",
   "website": "https://mistral.ai/products/vibe",
@@ -13,23 +13,23 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-darwin-aarch64-2.20.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-darwin-aarch64-2.21.0.zip",
         "cmd": "./vibe-acp"
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-darwin-x86_64-2.20.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-darwin-x86_64-2.21.0.zip",
         "cmd": "./vibe-acp"
       },
       "linux-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-linux-aarch64-2.20.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-linux-aarch64-2.21.0.zip",
         "cmd": "./vibe-acp"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-linux-x86_64-2.20.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-linux-x86_64-2.21.0.zip",
         "cmd": "./vibe-acp"
       },
       "windows-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.20.0/vibe-acp-windows-x86_64-2.20.0.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-windows-x86_64-2.21.0.zip",
         "cmd": "./vibe-acp.exe"
       }
     }

--- a/nova/agent.json
+++ b/nova/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "nova",
   "name": "Nova",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
   "repository": "https://github.com/Compass-Agentic-Platform/nova",
   "website": "https://www.compassap.ai/portfolio/nova.html",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "@compass-ai/nova@1.1.26",
+      "package": "@compass-ai/nova@1.1.27",
       "args": [
         "acp"
       ]

--- a/nova/agent.json
+++ b/nova/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "nova",
   "name": "Nova",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
   "repository": "https://github.com/Compass-Agentic-Platform/nova",
   "website": "https://www.compassap.ai/portfolio/nova.html",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "@compass-ai/nova@1.1.27",
+      "package": "@compass-ai/nova@1.1.28",
       "args": [
         "acp"
       ]

--- a/nova/agent.json
+++ b/nova/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "nova",
   "name": "Nova",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
   "repository": "https://github.com/Compass-Agentic-Platform/nova",
   "website": "https://www.compassap.ai/portfolio/nova.html",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "@compass-ai/nova@1.1.28",
+      "package": "@compass-ai/nova@1.1.29",
       "args": [
         "acp"
       ]

--- a/nova/agent.json
+++ b/nova/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "nova",
   "name": "Nova",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
   "repository": "https://github.com/Compass-Agentic-Platform/nova",
   "website": "https://www.compassap.ai/portfolio/nova.html",
@@ -12,7 +12,7 @@
   "icon": "./icon.svg",
   "distribution": {
     "npx": {
-      "package": "@compass-ai/nova@1.1.25",
+      "package": "@compass-ai/nova@1.1.26",
       "args": [
         "acp"
       ]

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.17.19",
+  "version": "1.17.20",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.17.18",
+  "version": "1.17.19",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.19/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.17.20",
+  "version": "1.18.0",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.17.17",
+  "version": "1.17.18",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.17/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.17/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.17/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.17/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.17/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.17/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.2/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.0/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.1/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "description": "The open source coding agent",
   "repository": "https://github.com/anomalyco/opencode",
   "website": "https://opencode.ai",
@@ -13,42 +13,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.5/opencode-darwin-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.5/opencode-darwin-x64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-arm64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.5/opencode-linux-arm64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-x64.tar.gz",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.5/opencode-linux-x64.tar.gz",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-arm64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.5/opencode-windows-arm64.zip",
         "cmd": "./opencode",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-x64.zip",
+        "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.5/opencode-windows-x64.zip",
         "cmd": "./opencode.exe",
         "args": [
           "acp"

--- a/pi-acp/agent.json
+++ b/pi-acp/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "pi-acp",
   "name": "pi ACP",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "ACP adapter for pi coding agent",
   "repository": "https://github.com/svkozak/pi-acp",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "MIT",
   "distribution": {
     "npx": {
-      "package": "pi-acp@0.0.31"
+      "package": "pi-acp@0.0.32"
     }
   }
 }

--- a/poolside/agent.json
+++ b/poolside/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "poolside",
   "name": "Poolside",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Poolside's coding agent",
   "repository": "https://github.com/poolsideai/pool",
   "website": "https://poolside.ai",
@@ -12,42 +12,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.10/pool-darwin-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-arm64.tar.gz",
         "cmd": "./pool-darwin-arm64",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.10/pool-darwin-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-amd64.tar.gz",
         "cmd": "./pool-darwin-amd64",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.10/pool-linux-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-arm64.tar.gz",
         "cmd": "./pool-linux-arm64",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.10/pool-linux-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-amd64.tar.gz",
         "cmd": "./pool-linux-amd64",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.10/pool-windows-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-arm64.tar.gz",
         "cmd": "./pool-windows-arm64.exe",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.10/pool-windows-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-amd64.tar.gz",
         "cmd": "./pool-windows-amd64.exe",
         "args": [
           "acp"

--- a/poolside/agent.json
+++ b/poolside/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "poolside",
   "name": "Poolside",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Poolside's coding agent",
   "repository": "https://github.com/poolsideai/pool",
   "website": "https://poolside.ai",
@@ -12,42 +12,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-darwin-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-darwin-arm64.tar.gz",
         "cmd": "./pool-darwin-arm64",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-darwin-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-darwin-amd64.tar.gz",
         "cmd": "./pool-darwin-amd64",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-linux-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-linux-arm64.tar.gz",
         "cmd": "./pool-linux-arm64",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-linux-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-linux-amd64.tar.gz",
         "cmd": "./pool-linux-amd64",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-windows-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-windows-arm64.tar.gz",
         "cmd": "./pool-windows-arm64.exe",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-windows-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-windows-amd64.tar.gz",
         "cmd": "./pool-windows-amd64.exe",
         "args": [
           "acp"

--- a/poolside/agent.json
+++ b/poolside/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "poolside",
   "name": "Poolside",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Poolside's coding agent",
   "repository": "https://github.com/poolsideai/pool",
   "website": "https://poolside.ai",
@@ -12,42 +12,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-darwin-arm64.tar.gz",
         "cmd": "./pool-darwin-arm64",
         "args": [
           "acp"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-darwin-amd64.tar.gz",
         "cmd": "./pool-darwin-amd64",
         "args": [
           "acp"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-linux-arm64.tar.gz",
         "cmd": "./pool-linux-arm64",
         "args": [
           "acp"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-linux-amd64.tar.gz",
         "cmd": "./pool-linux-amd64",
         "args": [
           "acp"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-arm64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-windows-arm64.tar.gz",
         "cmd": "./pool-windows-arm64.exe",
         "args": [
           "acp"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-amd64.tar.gz",
+        "archive": "https://downloads.poolside.ai/pool/v1.0.12/pool-windows-amd64.tar.gz",
         "cmd": "./pool-windows-amd64.exe",
         "args": [
           "acp"

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-code",
   "name": "Qwen Code",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Alibaba's Qwen coding assistant",
   "repository": "https://github.com/QwenLM/qwen-code",
   "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@qwen-code/qwen-code@0.20.0",
+      "package": "@qwen-code/qwen-code@0.20.1",
       "args": [
         "--acp",
         "--experimental-skills"

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-code",
   "name": "Qwen Code",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Alibaba's Qwen coding assistant",
   "repository": "https://github.com/QwenLM/qwen-code",
   "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@qwen-code/qwen-code@0.20.1",
+      "package": "@qwen-code/qwen-code@0.21.0",
       "args": [
         "--acp",
         "--experimental-skills"

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-code",
   "name": "Qwen Code",
-  "version": "0.19.11",
+  "version": "0.19.12",
   "description": "Alibaba's Qwen coding assistant",
   "repository": "https://github.com/QwenLM/qwen-code",
   "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@qwen-code/qwen-code@0.19.11",
+      "package": "@qwen-code/qwen-code@0.19.12",
       "args": [
         "--acp",
         "--experimental-skills"

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-code",
   "name": "Qwen Code",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "description": "Alibaba's Qwen coding assistant",
   "repository": "https://github.com/QwenLM/qwen-code",
   "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@qwen-code/qwen-code@0.19.9",
+      "package": "@qwen-code/qwen-code@0.19.10",
       "args": [
         "--acp",
         "--experimental-skills"

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-code",
   "name": "Qwen Code",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "description": "Alibaba's Qwen coding assistant",
   "repository": "https://github.com/QwenLM/qwen-code",
   "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@qwen-code/qwen-code@0.19.8",
+      "package": "@qwen-code/qwen-code@0.19.9",
       "args": [
         "--acp",
         "--experimental-skills"

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-code",
   "name": "Qwen Code",
-  "version": "0.19.10",
+  "version": "0.19.11",
   "description": "Alibaba's Qwen coding assistant",
   "repository": "https://github.com/QwenLM/qwen-code",
   "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@qwen-code/qwen-code@0.19.10",
+      "package": "@qwen-code/qwen-code@0.19.11",
       "args": [
         "--acp",
         "--experimental-skills"

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-code",
   "name": "Qwen Code",
-  "version": "0.19.12",
+  "version": "0.20.0",
   "description": "Alibaba's Qwen coding assistant",
   "repository": "https://github.com/QwenLM/qwen-code",
   "website": "https://qwenlm.github.io/qwen-code-docs/en/users/overview",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "npx": {
-      "package": "@qwen-code/qwen-code@0.19.12",
+      "package": "@qwen-code/qwen-code@0.20.0",
       "args": [
         "--acp",
         "--experimental-skills"

--- a/sigit/agent.json
+++ b/sigit/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "sigit",
   "name": "siGit Code",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Local-first coding agent. Runs entirely on your machine with optional on-device LLM inference via Onde.",
   "repository": "https://github.com/getsigit/sigit",
   "website": "https://github.com/getsigit/sigit",
@@ -12,32 +12,32 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.0/sigit-macos-arm64.tar.gz",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-macos-arm64.tar.gz",
         "cmd": "./sigit"
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.0/sigit-macos-amd64.tar.gz",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-macos-amd64.tar.gz",
         "cmd": "./sigit"
       },
       "linux-aarch64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.0/sigit-linux-arm64",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-linux-arm64",
         "cmd": "./sigit-linux-arm64"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.0/sigit-linux-amd64",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-linux-amd64",
         "cmd": "./sigit-linux-amd64"
       },
       "windows-aarch64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.0/sigit-win-arm64.exe",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-win-arm64.exe",
         "cmd": "./sigit-win-arm64.exe"
       },
       "windows-x86_64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.0/sigit-win-amd64.exe",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-win-amd64.exe",
         "cmd": "./sigit-win-amd64.exe"
       }
     },
     "npx": {
-      "package": "@smbcloud/sigit@1.4.0"
+      "package": "@smbcloud/sigit@1.4.1"
     }
   }
 }

--- a/sigit/agent.json
+++ b/sigit/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "sigit",
   "name": "siGit Code",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Local-first coding agent. Runs entirely on your machine with optional on-device LLM inference via Onde.",
   "repository": "https://github.com/getsigit/sigit",
   "website": "https://github.com/getsigit/sigit",
@@ -12,32 +12,32 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-macos-arm64.tar.gz",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-macos-arm64.tar.gz",
         "cmd": "./sigit"
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-macos-amd64.tar.gz",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-macos-amd64.tar.gz",
         "cmd": "./sigit"
       },
       "linux-aarch64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-linux-arm64",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-linux-arm64",
         "cmd": "./sigit-linux-arm64"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-linux-amd64",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-linux-amd64",
         "cmd": "./sigit-linux-amd64"
       },
       "windows-aarch64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-win-arm64.exe",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-win-arm64.exe",
         "cmd": "./sigit-win-arm64.exe"
       },
       "windows-x86_64": {
-        "archive": "https://github.com/getsigit/sigit/releases/download/v1.4.1/sigit-win-amd64.exe",
+        "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-win-amd64.exe",
         "cmd": "./sigit-win-amd64.exe"
       }
     },
     "npx": {
-      "package": "@smbcloud/sigit@1.4.1"
+      "package": "@smbcloud/sigit@1.5.0"
     }
   }
 }


### PR DESCRIPTION
## What

`CLAUDE.md` becomes a symlink to `AGENTS.md`.

## Why

`CLAUDE.md` was a hand-written paragraph whose only job was to say "read AGENTS.md". Across the harn and burin repos there were six different wordings of that same sentence, each one a file that can go stale independently of the thing it points at. A symlink says it once and cannot drift.

This matches burin-code and the connector repos, which already do this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)