### PR TITLE
Add Claudexor

### DIFF
--- a/claudexor/agent.json
+++ b/claudexor/agent.json
@@ -1,17 +1,17 @@
 {
   "id": "claudexor",
   "name": "Claudexor",
-  "version": "3.1.1",
-  "description": "Local-first control plane for orchestrating multiple AI coding agents",
+  "version": "3.1.2",
+  "description": "Local-first control plane for Claude Code, Codex, Cursor, and OpenCode with quota-aware rotation across multiple native subscription accounts of the same Claude Code or Codex harness",
   "repository": "https://github.com/razzant/claudexor",
-  "website": "https://razzant.github.io/claudexor/",
+  "website": "https://claudexor.ai/",
   "authors": [
     "Anton Razzhigaev"
   ],
   "license": "MIT",
   "distribution": {
     "npx": {
-      "package": "claudexor@3.1.1",
+      "package": "claudexor@3.1.2",
       "args": [
         "acp",
         "serve"

--- a/claudexor/agent.json
+++ b/claudexor/agent.json
@@ -1,0 +1,21 @@
+{
+  "id": "claudexor",
+  "name": "Claudexor",
+  "version": "3.1.1",
+  "description": "Local-first control plane for orchestrating multiple AI coding agents",
+  "repository": "https://github.com/razzant/claudexor",
+  "website": "https://razzant.github.io/claudexor/",
+  "authors": [
+    "Anton Razzhigaev"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "claudexor@3.1.1",
+      "args": [
+        "acp",
+        "serve"
+      ]
+    }
+  }
+}

--- a/claudexor/icon.svg
+++ b/claudexor/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" fill-rule="evenodd" d="M7.5 1.25a6.25 6.25 0 1 0 0 12.5 6.25 6.25 0 0 0 0-12.5Zm0 2a4.25 4.25 0 1 0 0 8.5 4.25 4.25 0 0 0 0-8.5Z"/>
+  <path fill="currentColor" d="m12.5 4.25.97 1.78 1.78.97-1.78.97-.97 1.78-.97-1.78L9.75 7l1.78-.97.97-1.78Z"/>
+</svg>


### PR DESCRIPTION
Adds Claudexor 3.1.2 as an npm-distributed ACP agent through claudexor acp serve, together with the required 16x16 currentColor icon. Claudexor is a local-first control plane for Claude Code, Codex, Cursor, and OpenCode, including quota-aware rotation across multiple native subscription accounts of the same Claude Code or Codex harness.

The full registry build with URL validation passes locally, and the published 3.1.2 package passes the official ACP authentication check with Codex Terminal Auth.
