### PR TITLE
Add hive agent

### DIFF
--- a/hive/agent.json
+++ b/hive/agent.json
@@ -1,0 +1,34 @@
+{
+  "id": "hive",
+  "name": "Hive",
+  "version": "0.2.0",
+  "description": "Native Rust YOLO coding agent",
+  "repository": "https://github.com/xn0tdev/hive",
+  "authors": ["gotlib"],
+  "license": "MIT",
+  "icon": "./icon.svg",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/xn0tdev/hive/releases/download/v0.2.0/hive-aarch64-apple-darwin.tar.gz",
+        "cmd": "./hive",
+        "args": ["--acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/xn0tdev/hive/releases/download/v0.2.0/hive-x86_64-apple-darwin.tar.gz",
+        "cmd": "./hive",
+        "args": ["--acp"]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/xn0tdev/hive/releases/download/v0.2.0/hive-x86_64-unknown-linux-gnu.tar.gz",
+        "cmd": "./hive",
+        "args": ["--acp"]
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/xn0tdev/hive/releases/download/v0.2.0/hive-x86_64-pc-windows-msvc.zip",
+        "cmd": "hive.exe",
+        "args": ["--acp"]
+      }
+    }
+  }
+}

--- a/hive/icon.svg
+++ b/hive/icon.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 21 5" fill="currentColor">
+<!-- HIVE wordmark — ASCII block letters, centered in square viewBox -->
+<!-- Row 0: █   █ ███ █   █ █████ -->
+<rect x="0"  y="0" width="1" height="1"/>
+<rect x="4"  y="0" width="1" height="1"/>
+<rect x="6"  y="0" width="3" height="1"/>
+<rect x="10" y="0" width="1" height="1"/>
+<rect x="14" y="0" width="1" height="1"/>
+<rect x="16" y="0" width="5" height="1"/>
+<!-- Row 1: █   █  █  █   █ █     -->
+<rect x="0"  y="1" width="1" height="1"/>
+<rect x="4"  y="1" width="1" height="1"/>
+<rect x="7"  y="1" width="1" height="1"/>
+<rect x="10" y="1" width="1" height="1"/>
+<rect x="14" y="1" width="1" height="1"/>
+<rect x="16" y="1" width="1" height="1"/>
+<!-- Row 2: █████  █  █   █ ████  -->
+<rect x="0"  y="2" width="5" height="1"/>
+<rect x="7"  y="2" width="1" height="1"/>
+<rect x="10" y="2" width="1" height="1"/>
+<rect x="14" y="2" width="1" height="1"/>
+<rect x="16" y="2" width="4" height="1"/>
+<!-- Row 3: █   █  █   █ █  █     -->
+<rect x="0"  y="3" width="1" height="1"/>
+<rect x="4"  y="3" width="1" height="1"/>
+<rect x="7"  y="3" width="1" height="1"/>
+<rect x="11" y="3" width="1" height="1"/>
+<rect x="13" y="3" width="1" height="1"/>
+<rect x="16" y="3" width="1" height="1"/>
+<!-- Row 4: █   █ ███   █   █████ -->
+<rect x="0"  y="4" width="1" height="1"/>
+<rect x="4"  y="4" width="1" height="1"/>
+<rect x="6"  y="4" width="3" height="1"/>
+<rect x="12" y="4" width="1" height="1"/>
+<rect x="16" y="4" width="5" height="1"/>
+</svg>


### PR DESCRIPTION
## Hive — Native Rust Coding Agent

Hive is a native Rust coding agent that speaks the Agent Client Protocol (ACP) over stdio.

- **Source:** https://github.com/xn0tdev/hive
- **Releases:** https://github.com/xn0tdev/hive/releases
- **License:** MIT

### Platforms

- macOS ARM (darwin-aarch64)
- macOS Intel (darwin-x86_64)
- Linux x86_64 (linux-x86_64)
- Windows x86_64 (windows-x86_64)

### ACP Support

Implements ACP v1: `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/set_mode`, plus `session/update` notifications for agent messages, thoughts, tool calls (with diffs), plan updates, mode changes, and usage.

### Notes

- `sha256` fields will be added once the first release CI run produces archives with checksums. The release workflow is already in place (tag-triggered, 4-platform matrix build).
- Hive takes API keys from `~/.config/hive/config.toml` or environment variables — no OAuth flow.