### PR TITLE
fix: use Vibe ACP tar archives on non-Windows

### DIFF
--- a/mistral-vibe/agent.json
+++ b/mistral-vibe/agent.json
@@ -13,24 +13,24 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-aarch64-2.23.3.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-aarch64-2.23.3.tar.gz",
         "cmd": "./vibe-acp",
-        "sha256": "39b1b0293e778303c4ab1be6bdeed28ab769c9eb94cea39783a475c857900f83"
+        "sha256": "cca5c15f20b2048c1d319892e337e8a39e2aa9f3829c9bc96d517ad6f5698846"
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-x86_64-2.23.3.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-x86_64-2.23.3.tar.gz",
         "cmd": "./vibe-acp",
-        "sha256": "99a89078e8ac040685aa34696b9e94b9e7ccbe1af6b978763b1552c39baec8e6"
+        "sha256": "fd82665d03bbc4d94713b06364b71506a3042376f49a40c25073b3b8cfeefbc7"
       },
       "linux-aarch64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-aarch64-2.23.3.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-aarch64-2.23.3.tar.gz",
         "cmd": "./vibe-acp",
-        "sha256": "cad8302d8d9f5448292b6371c44fb827b3dd3027f8db0535291c81219fb46ba3"
+        "sha256": "eb33a1c7064745a437ad109aac26546a6a961a0212940bf9551f44dd731b4a5b"
       },
       "linux-x86_64": {
-        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-x86_64-2.23.3.zip",
+        "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-x86_64-2.23.3.tar.gz",
         "cmd": "./vibe-acp",
-        "sha256": "b5f6e9e8411f32238eeecf130b18a7f0256f1b6db4afcfa8b3548d480ab42b26"
+        "sha256": "4166cc3457469be487897979a10d866c5c6587b32d621656f6c0b5614fce5986"
       },
       "windows-x86_64": {
         "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-windows-x86_64-2.23.3.zip",


### PR DESCRIPTION
Mistral Vibe v2.23.2 has `.tar.gz` ACP archives for macOS and Linux. These archives preserve the Python framework symlinks that the ZIP install can lose during extraction.

The automatic version update changed Mistral Vibe from v2.23.1 to v2.23.2 but retained the old `.zip` suffix. This change points the four non-Windows targets at the published tar archives and updates their SHA-256 values. Windows stays on ZIP.

Sources:

- https://github.com/mistralai/mistral-vibe/releases/tag/v2.23.2
- https://github.com/mistralai/mistral-vibe/blob/v2.23.2/distribution/zed/extension.toml

Tests:

- `uv run --with jsonschema .github/workflows/build_registry.py`
- `uv run --with ruff ruff check .github/workflows`
- `uv run --with ruff ruff format --check .`
- `uv run --with pytest pytest tests/ -v` (121 passed)
