### PR TITLE
feat: add kiro-gateway agent

### DIFF
--- a/kiro-gateway/agent.json
+++ b/kiro-gateway/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "kiro-gateway",
   "name": "Kiro Gateway",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "ACP-compliant bridge for Kiro — routes completions through kiro-cli with OpenAI, Anthropic, and native ACP interfaces",
   "repository": "https://github.com/ankitcharolia/kiro-gateway",
   "website": "https://github.com/ankitcharolia/kiro-gateway",

--- a/kiro-gateway/agent.json
+++ b/kiro-gateway/agent.json
@@ -1,0 +1,18 @@
+{
+  "id": "kiro-gateway",
+  "name": "Kiro Gateway",
+  "version": "2.3.2",
+  "description": "ACP-compliant bridge for Kiro — routes completions through kiro-cli with OpenAI, Anthropic, and native ACP interfaces",
+  "repository": "https://github.com/ankitcharolia/kiro-gateway",
+  "website": "https://github.com/ankitcharolia/kiro-gateway",
+  "authors": [
+    "Ankit Charolia <ankitcharolia@gmail.com>"
+  ],
+  "license": "AGPL-3.0-only",
+  "distribution": {
+    "uvx": {
+      "package": "kiro-gateway",
+      "args": ["acp"]
+    }
+  }
+}

--- a/kiro-gateway/icon.svg
+++ b/kiro-gateway/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M3 2h2v5.5L9.5 3H12L7.5 8 12 13H9.5L5 8.5V14H3V2z"/>
+</svg>


### PR DESCRIPTION
  
  Adds **kiro-gateway** — an ACP-compliant bridge for [Kiro](https://kiro.dev) that routes all completions through the official \`kiro-cli\` binary via ACP (JSON-RPC 2.0 over stdio).
  
  ### What it does
  
  kiro-gateway lets any OpenAI-compatible or Anthropic-compatible AI harness (Cursor, Cline, Claude Code, Kilo Code, OpenCode, Zed, JetBrains, etc.) use a single Kiro subscription by translating between
  OpenAI/Anthropic/native ACP APIs and \`kiro-cli acp\`.
  
  ### Distribution
  
  - **Type:** \`uvx\` (PyPI package)
  - **Command:** \`uvx kiro-gateway acp\` — speaks ACP (JSON-RPC 2.0) over stdin/stdout
  - **Auth:** Terminal auth via \`kiro-cli login\` (interactive)
  
  ### Links
  
  - Repository: https://github.com/ankitcharolia/kiro-gateway
  - License: AGPL-3.0-only
  
  ### Checklist
  
  - [x] \`agent.json\` with required fields (\`id\`, \`name\`, \`version\`, \`description\`, \`distribution\`)
  - [x] \`icon.svg\` — 16×16, monochrome with \`currentColor\`
  - [x] Distribution method: \`uvx\` with \`package\` and \`args\`
  - [x] Auth method: \`terminal\` (delegates to \`kiro-cli login\`)" 2>&1