### PR TITLE
Point Junie GA binaries to junie-acp-release (2783.3)

### DIFF
--- a/junie/agent.json
+++ b/junie/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "junie",
   "name": "Junie",
-  "version": "2698.3.0",
+  "version": "2783.3.0",
   "description": "AI Coding Agent by JetBrains",
   "repository": "https://github.com/JetBrains/junie-acp-release",
   "website": "https://junie.jetbrains.com",
@@ -12,42 +12,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-macos-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-aarch64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": [
           "--acp=true"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-macos-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-amd64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": [
           "--acp=true"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-linux-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-aarch64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": [
           "--acp=true"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-linux-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-amd64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": [
           "--acp=true"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-windows-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-amd64.zip",
         "cmd": "./junie/junie.exe",
         "args": [
           "--acp=true"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-windows-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-aarch64.zip",
         "cmd": "./junie/junie.exe",
         "args": [
           "--acp=true"

--- a/junie/agent.json
+++ b/junie/agent.json
@@ -12,42 +12,42 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-macos-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-macos-aarch64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": [
           "--acp=true"
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-macos-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-macos-amd64.zip",
         "cmd": "./Applications/junie.app/Contents/MacOS/junie",
         "args": [
           "--acp=true"
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-linux-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-linux-aarch64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": [
           "--acp=true"
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-linux-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-linux-amd64.zip",
         "cmd": "./junie-app/bin/junie",
         "args": [
           "--acp=true"
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-windows-amd64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-windows-amd64.zip",
         "cmd": "./junie/junie.exe",
         "args": [
           "--acp=true"
         ]
       },
       "windows-aarch64": {
-        "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-windows-aarch64.zip",
+        "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2698.3/junie-release-2698.3-windows-aarch64.zip",
         "cmd": "./junie/junie.exe",
         "args": [
           "--acp=true"


### PR DESCRIPTION
## Summary

Update `junie/agent.json` so public ACP installs Junie GA binaries from [`JetBrains/junie-acp-release`](https://github.com/JetBrains/junie-acp-release) (not `JetBrains/junie`), and **bump the version to a GA tag that actually has assets**.

| Field | Value |
|---|---|
| **version** | `2783.3.0` (was `2698.3.0`) |
| **repository** | `https://github.com/JetBrains/junie-acp-release` (unchanged) |
| **GA tag / download path** | `2783.3` |

### Why the bump

- Tag **`2698.3`** on `junie-acp-release` is signal-only (**0 assets** → archive URLs **404**).
- Tag **`2783.3`** is a plain non-prerelease GA with **all 6 platform zips** published.

### Archive URL shape

```text
https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-<platform>.zip
```

Platform filename tokens (unchanged convention):

| Registry key | Zip suffix |
|---|---|
| `darwin-aarch64` | `macos-aarch64` |
| `darwin-x86_64` | `macos-amd64` |
| `linux-aarch64` | `linux-aarch64` |
| `linux-x86_64` | `linux-amd64` |
| `windows-aarch64` | `windows-aarch64` |
| `windows-x86_64` | `windows-amd64` |

`cmd` / `args` unchanged.

### Pre-merge verification

All six archives checked against the live release (HTTP **200** / range **206** after redirects), e.g.:

- https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-aarch64.zip
- https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-amd64.zip
- https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-aarch64.zip
- https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-amd64.zip
- https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-aarch64.zip
- https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-amd64.zip

### Notes

- Public ACP cron discovers versions from the `repository` release tags; this PR also pins explicit archive URLs required by the registry schema/CI.
- EAP / staging tags (`*-EAP`, `*-staging`) are intentionally not used here.