### PR TITLE
Add omp agent to the registry

### DIFF
--- a/omp/agent.json
+++ b/omp/agent.json
@@ -1,0 +1,16 @@
+{
+  "id": "omp",
+  "name": "Oh My Pi",
+  "version": "17.3.3",
+  "description": "A coding agent with the IDE wired in: subagents, plan mode, LSP, DAP, hindsight memory, time-traveling rules",
+  "repository": "https://github.com/can1357/oh-my-pi",
+  "website": "https://omp.sh",
+  "authors": ["can1357"],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "@oh-my-pi/pi-coding-agent@17.3.3",
+      "args": ["acp"]
+    }
+  }
+}

--- a/omp/icon.svg
+++ b/omp/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <!-- Pi symbol, monochrome -->
+  <path fill="currentColor" d="M2 3h12v2.5H2z"/>
+  <path fill="currentColor" d="M2 5.5h2.5V13H2z"/>
+  <path fill="currentColor" d="M11.5 5.5H14V10h-2.5z"/>
+</svg>


### PR DESCRIPTION
Adds [omp (Oh My Pi)](https://omp.sh) — a terminal coding agent with a native Rust engine (subagents, plan mode, LSP, DAP, hindsight memory) — to the ACP registry.

- **Agent**: `omp acp` — ACP server over stdio (protocolVersion 1)
- **Distribution**: npm [`@oh-my-pi/pi-coding-agent`](https://www.npmjs.com/package/@oh-my-pi/pi-coding-agent) via npx, bin `omp` + args `["acp"]` — versions auto-update from npm
- **Authentication**: verified — `initialize` returns `authMethods: [{"id":"agent","name":"Use existing local credentials",...}]` (Agent Auth, `type` defaults to `agent` per AUTHENTICATION.md)
- **Source**: https://github.com/can1357/oh-my-pi (MIT)
- **Icon**: custom 16x16 monochrome `currentColor` Pi symbol (upstream asset is 120x90 with hardcoded colors, so it cannot be used as-is)

Handshake verified against omp 17.2.4/17.3.3 in an isolated HOME (sandbox): session capabilities + agent auth method advertised correctly.
