### PR TITLE
fix: pin Claude Agent 0.66.0 for JetBrains

### DIFF
--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -648,10 +648,16 @@ def build_registry(dry_run: bool = False):
     # Agents flagged as bundled in the JetBrains registry
     JETBRAINS_BUNDLED_IDS = {"claude-acp"}
 
+    JETBRAINS_CLAUDE_ACP_VERSION = "0.66.0"
+
     def patch_agent_for_jetbrains(agent):
         patched = copy.deepcopy(agent)
         if patched["id"] == "claude-acp":
             assert "npx" in patched["distribution"], "claude-acp must have npx distribution"
+            patched["version"] = JETBRAINS_CLAUDE_ACP_VERSION
+            patched["distribution"]["npx"]["package"] = (
+                f"@agentclientprotocol/claude-agent-acp@{JETBRAINS_CLAUDE_ACP_VERSION}"
+            )
             patched["distribution"]["npx"].setdefault("args", []).append("--hide-claude-auth")
         if patched["id"] in JETBRAINS_BUNDLED_IDS:
             patched["bundled"] = True


### PR DESCRIPTION
## Summary

- Pin Claude Agent to `0.66.0` only in `registry-for-jetbrains.json`.
- Keep the default registry on the current Claude Agent version.
- Preserve the JetBrains-specific `--hide-claude-auth` argument and bundled marker.

## Why

Claude Agent `0.67.0` causes the JetBrains authentication method to loop without completing. Pinning the JetBrains registry entry to the last known-good `0.66.0` release provides a temporary mitigation while the underlying regression is investigated.

Tracked in:

- https://github.com/agentclientprotocol/claude-agent-acp/issues/999
- https://youtrack.jetbrains.com/issue/LLM-30551/Claude-Agent-JetBrains-authentication-method-loops-and-does-not-complete

## Validation

- `uv run --with jsonschema .github/workflows/build_registry.py`
- Confirmed the default registry contains Claude Agent `0.67.0`.
- Confirmed the JetBrains registry contains Claude Agent `0.66.0` with `bundled: true` and `--hide-claude-auth`.
