### PR TITLE
Add Longbridge agent

### DIFF
--- a/longbridge/agent.json
+++ b/longbridge/agent.json
@@ -1,0 +1,56 @@
+{
+  "id": "longbridge",
+  "name": "Longbridge AI",
+  "version": "0.27.1",
+  "description": "Research US and HK stocks with market data, fundamentals, analyst ratings, news, filings, screeners, movers, rankings, and short interest. Connect your Longbridge account to analyze balances, positions, profit and loss, cash flow, statements, watchlists, and order history.",
+  "repository": "https://github.com/longbridge/longbridge-terminal",
+  "website": "https://longbridge.com/ai",
+  "authors": [
+    "Longbridge"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/longbridge/longbridge-terminal/releases/download/v0.27.1/longbridge-terminal-darwin-arm64.tar.gz",
+        "sha256": "52b540cd00b40d29782be78e05a1e1a1a4c1ac19773d7d152ceeaf36ac197508",
+        "cmd": "./longbridge",
+        "args": [
+          "acp"
+        ]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/longbridge/longbridge-terminal/releases/download/v0.27.1/longbridge-terminal-darwin-amd64.tar.gz",
+        "sha256": "36c26ad056273114142e157ac80cc84c472284222ece926f67f66f2a3663b9f8",
+        "cmd": "./longbridge",
+        "args": [
+          "acp"
+        ]
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/longbridge/longbridge-terminal/releases/download/v0.27.1/longbridge-terminal-linux-arm64.tar.gz",
+        "sha256": "4f4010b49e099001018f1f64bc698a974bc65156045e6c56915e33a3cf7a32d0",
+        "cmd": "./longbridge",
+        "args": [
+          "acp"
+        ]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/longbridge/longbridge-terminal/releases/download/v0.27.1/longbridge-terminal-linux-amd64.tar.gz",
+        "sha256": "ad54ea5ecedcda8f0ea0e41eb6387b2098bbe2326201d43063cb05f6f20d4466",
+        "cmd": "./longbridge",
+        "args": [
+          "acp"
+        ]
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/longbridge/longbridge-terminal/releases/download/v0.27.1/longbridge-terminal-windows-amd64.zip",
+        "sha256": "c26af9231843e7502674b4dd15f6aabed867486f58681b27e7a1e563b4e2831b",
+        "cmd": "longbridge.exe",
+        "args": [
+          "acp"
+        ]
+      }
+    }
+  }
+}

--- a/longbridge/icon.svg
+++ b/longbridge/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 69 69">
+  <path fill="currentColor" d="M0 0h3v69H0V0Zm7 0h10v69H7V0Zm14 60h9v9h-9v-9Zm12 0h3v9h-3v-9Zm7-8h10v17H40V52Zm13-9h9v26h-9V43Zm13-17h3v43h-3V26Z"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Longbridge** to the registry — an ACP agent for equity research and portfolio analysis on US and HK markets.

- `longbridge/agent.json` — binary distribution for `darwin-aarch64`, `darwin-x86_64`, `linux-aarch64`, `linux-x86_64`, `windows-x86_64`, each pinned with a SHA-256 checksum, launched via `longbridge acp`
- `longbridge/icon.svg` — 16x16 monochrome SVG using `currentColor`

Source: https://github.com/longbridge/longbridge-terminal (release [v0.27.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.27.1))

## Validation

```
$ uv run --with jsonschema .github/workflows/build_registry.py
Added agent: longbridge v0.27.1

$ python3 .github/workflows/verify_agents.py --auth-check --agent longbridge
[1/1] longbridge (binary)
    ✓ Success: Auth OK: longbridge-login(terminal)
  Passed: 1  Failed: 0  Skipped: 0
```

Auth is exposed as a `terminal` method (`longbridge auth login`, Longbridge OAuth), per [AUTHENTICATION.md](AUTHENTICATION.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)