### PR TITLE
Add 5dive agent

### DIFF
--- a/fivedive/agent.json
+++ b/fivedive/agent.json
@@ -1,0 +1,33 @@
+{
+  "id": "fivedive",
+  "name": "5dive",
+  "version": "0.19.33",
+  "description": "Attach an ACP client to a named agent in your running 5dive fleet, with its memory, tasks and org position intact, instead of opening a blank session. The roster arrives as slash commands. Runs where the fleet runs.",
+  "repository": "https://github.com/5dive-ai/5dive",
+  "website": "https://5dive.ai",
+  "license": "MIT",
+  "distribution": {
+    "binary": {
+      "linux-x86_64": {
+        "archive": "https://github.com/5dive-ai/5dive/archive/refs/tags/v0.19.33.tar.gz",
+        "cmd": "5dive-0.19.33/5dive",
+        "args": ["acp"]
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/5dive-ai/5dive/archive/refs/tags/v0.19.33.tar.gz",
+        "cmd": "5dive-0.19.33/5dive",
+        "args": ["acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/5dive-ai/5dive/archive/refs/tags/v0.19.33.tar.gz",
+        "cmd": "5dive-0.19.33/5dive",
+        "args": ["acp"]
+      },
+      "darwin-aarch64": {
+        "archive": "https://github.com/5dive-ai/5dive/archive/refs/tags/v0.19.33.tar.gz",
+        "cmd": "5dive-0.19.33/5dive",
+        "args": ["acp"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the `fivedive` entry: 5dive is a multi-agent runtime CLI, and this entry attaches an ACP client to a named agent in a running fleet, with its memory, tasks and org position intact. The agent lists the fleet where the fleet runs.
