### PR TITLE
Add pi-acp-jetbrain agent

### DIFF
--- a/pi-acp-jetbrain/agent.json
+++ b/pi-acp-jetbrain/agent.json
@@ -1,0 +1,14 @@
+{
+  "id": "pi-acp-jetbrain",
+  "name": "pi-acp-jetbrain",
+  "version": "0.0.36",
+  "description": "Run the pi coding agent inside JetBrains IDEs over the Agent Client Protocol",
+  "repository": "https://github.com/ryan-brosas/pi-acp-jetbrain",
+  "authors": ["Sergii Kozak"],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "pi-acp-jetbrain@0.0.36"
+    }
+  }
+}

--- a/pi-acp-jetbrain/icon.svg
+++ b/pi-acp-jetbrain/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect x="3" y="3" width="2.5" height="10" fill="currentColor"/>
+  <rect x="10.5" y="3" width="2.5" height="10" fill="currentColor"/>
+  <rect x="6.75" y="6.75" width="2.5" height="2.5" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
Adds the pi-acp-jetbrain agent to the registry.

pi-acp-jetbrain runs the pi coding agent (@earendil-works/pi-coding-agent) inside JetBrains IDEs. It speaks ACP over stdio and bridges the IDE's own MCP tools to the agent. Initialize returns authMethods as required.

Repo: https://github.com/ryan-brosas/pi-acp-jetbrain
npm: https://www.npmjs.com/package/pi-acp-jetbrain