### PR TITLE
Add xiaoyu agent

### DIFF
--- a/xiaoyu/agent.json
+++ b/xiaoyu/agent.json
@@ -1,14 +1,14 @@
 {
   "id": "xiaoyu",
   "name": "小羽 (Xiaoyu)",
-  "version": "0.31.0",
+  "version": "0.31.3",
   "description": "Coding agent with plan mode, session restore, model selector, and multi-provider routing — terminal TUI and ACP in one Python package.",
   "repository": "https://github.com/pholex/zhinu",
   "authors": ["Fenghuang"],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "xiaoyu-agent==0.31.0",
+      "package": "xiaoyu-agent==0.31.3",
       "args": ["--acp"]
     }
   }

--- a/xiaoyu/agent.json
+++ b/xiaoyu/agent.json
@@ -1,14 +1,14 @@
 {
   "id": "xiaoyu",
   "name": "小羽 (Xiaoyu)",
-  "version": "0.31.3",
+  "version": "0.33.0",
   "description": "Coding agent with plan mode, session restore, model selector, and multi-provider routing — terminal TUI and ACP in one Python package.",
   "repository": "https://github.com/pholex/zhinu",
   "authors": ["Fenghuang"],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "xiaoyu-agent==0.31.3",
+      "package": "xiaoyu-agent==0.33.0",
       "args": ["--acp"]
     }
   }

--- a/xiaoyu/agent.json
+++ b/xiaoyu/agent.json
@@ -1,0 +1,15 @@
+{
+  "id": "xiaoyu",
+  "name": "小羽 (Xiaoyu)",
+  "version": "0.30.11",
+  "description": "Coding agent with plan mode, session restore, model selector, and multi-provider routing — terminal TUI and ACP in one Python package.",
+  "repository": "https://github.com/pholex/zhinu",
+  "authors": ["Fenghuang"],
+  "license": "MIT",
+  "distribution": {
+    "uvx": {
+      "package": "xiaoyu-agent==0.30.11",
+      "args": ["--acp"]
+    }
+  }
+}

--- a/xiaoyu/agent.json
+++ b/xiaoyu/agent.json
@@ -1,14 +1,14 @@
 {
   "id": "xiaoyu",
   "name": "小羽 (Xiaoyu)",
-  "version": "0.33.0",
+  "version": "0.40.0",
   "description": "Coding agent with plan mode, session restore, model selector, and multi-provider routing — terminal TUI and ACP in one Python package.",
   "repository": "https://github.com/pholex/zhinu",
   "authors": ["Fenghuang"],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "xiaoyu-agent==0.33.0",
+      "package": "xiaoyu-agent==0.40.0",
       "args": ["--acp"]
     }
   }

--- a/xiaoyu/agent.json
+++ b/xiaoyu/agent.json
@@ -1,14 +1,14 @@
 {
   "id": "xiaoyu",
   "name": "小羽 (Xiaoyu)",
-  "version": "0.30.11",
+  "version": "0.31.0",
   "description": "Coding agent with plan mode, session restore, model selector, and multi-provider routing — terminal TUI and ACP in one Python package.",
   "repository": "https://github.com/pholex/zhinu",
   "authors": ["Fenghuang"],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "xiaoyu-agent==0.30.11",
+      "package": "xiaoyu-agent==0.31.0",
       "args": ["--acp"]
     }
   }

--- a/xiaoyu/icon.svg
+++ b/xiaoyu/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M14 2C10 1 5.5 2.5 3.5 6 2.3 8.2 1.6 11.5 1 15c3.5-.6 6.8-1.3 9-2.5C13.5 10.5 15 6 14 2ZM12.6 3.4 2.6 13.4l.7.7 10-10Z"/></svg>


### PR DESCRIPTION
## Agent

小羽 (Xiaoyu) — a coding agent with plan mode, session restore (session/load),
native model selector (session config options), session modes, slash commands,
and image prompts. Single Python package, MIT licensed.

- Repository: https://github.com/pholex/zhinu
- Distribution: uvx (`xiaoyu-agent` on PyPI, wheel-only releases)
- Authentication: terminal method (`xiaoyu config` interactive wizard);
  returns `-32000 auth_required` from `session/new` when no provider is configured

## Validation

Ran locally before submitting (against the published v0.31.0 wheel):

- `build_registry.py --dry-run` — validated 40 agents successfully (xiaoyu v0.31.0 included)
- `verify_agents.py --agent xiaoyu --auth-check` — passed (uvx sandbox install + handshake)
- `check-jsonschema` against `agent.schema.json` — ok