### PR TITLE
feat: update @tencent-ai/codebuddy-code to 2.137.0 to resolve missing binary issue

### DIFF
--- a/codebuddy-code/agent.json
+++ b/codebuddy-code/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "codebuddy-code",
   "name": "Codebuddy Code",
-  "version": "2.106.7",
+  "version": "2.137.0",
   "description": "Tencent Cloud's official intelligent coding tool",
   "website": "https://www.codebuddy.cn/cli/",
   "authors": [
@@ -10,7 +10,7 @@
   "license": "Proprietary",
   "distribution": {
     "npx": {
-      "package": "@tencent-ai/codebuddy-code@2.106.7",
+      "package": "@tencent-ai/codebuddy-code@2.137.0",
       "args": [
         "--acp"
       ]

--- a/quarantine.json
+++ b/quarantine.json
@@ -1,6 +1,5 @@
 {
   "agoragentic-acp": "Postinstall script",
-  "codebuddy-code": "npx cannot determine executable to run",
   "crow-cli": "ACP initialize fails in crow-cli 0.1.25",
   "deepagents": "Missing npm dependency",
   "minion-code": "Python dependency issue",


### PR DESCRIPTION
The outdated @tencent-ai/codebuddy-code package has been missing the entry binary `codebuddy-code`. This PR updates it to the latest version on npm to make it work again. The corresponding entry in quarantine.json, added in #390, is also safe to be removed.

For further questions and/or permission from the Tencent CodeBuddy team, feel free to contact rikumiyu@tencent.com.