### PR TITLE
Add agent-vesper: Native Rust Reasoning Orchestrator

### DIFF
--- a/agent-vesper/agent.json
+++ b/agent-vesper/agent.json
@@ -1,0 +1,36 @@
+{
+  "id": "agent-vesper",
+  "name": "Agent Vesper",
+  "version": "0.20.44",
+  "description": "Agent Vesper \u2014 a Rust-native, provider-neutral ACP coding agent runtime featuring the Vesper Reasoning Orchestrator (VRO): 10 reasoning strategies (Direct, Plan-Then-Answer, Plan-Execute-Verify, Generate-Verify-Repair, Parallel Candidates Consensus/Judge, Tool-Grounded ReAct, Bounded Tree Search, Proposer-Critic-Adjudicator, Workflow-Replay-with-Verification), provider-routed auth, multi-model cross-provider candidate racing, calibrated Phase R3 budgets, and the mem0-equivalent cognitive memory engine. ACP-protocol-v1 stdio server for Z.ai GLM models and OpenAI-compatible local servers (LM Studio), installable as an ACP agent in Zed and other ACP-compatible editors.",
+  "repository": "https://github.com/99percentgrip/agent-vesper",
+  "website": "https://github.com/99percentgrip/agent-vesper",
+  "authors": [
+    "Aleksejs Kozlitins"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "binary": {
+      "darwin-x86_64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.44/agent-vesper-acp-darwin-x86_64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "darwin-aarch64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.44/agent-vesper-acp-darwin-aarch64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.44/agent-vesper-acp-linux-x86_64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.44/agent-vesper-acp-linux-aarch64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.44/agent-vesper-acp-windows-x86_64.zip",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Publishes `agent-vesper` to the public ACP Registry at **v0.20.44**.

This is the Rust-native Agent Vesper, a separate entry from `native-glm-acp`.

- **Repository:** https://github.com/99percentgrip/agent-vesper
- **Release:** https://github.com/99percentgrip/agent-vesper/releases/tag/v0.20.44
- **Install:** `curl -fsSL https://raw.githubusercontent.com/99percentgrip/agent-vesper/main/scripts/install.sh | sh`
- **ACP protocol:** v1 over stdio

## Assets

The manifest references published, checksum-backed archives for:

- Linux x86_64 and AArch64
- macOS x86_64 and Apple Silicon
- Windows x86_64

## Verification

- `cargo xtask verify` passed on the v0.20.44 source.
- PR quality, supply-chain, MSRV, and five-target foundation workflows passed.
- The tag-triggered five-platform release workflow passed.
- A clean Linux x86_64 installation verified both `agent-vesper-acp 0.20.44` and `agent-vesper-tui 0.20.44`.
