### PR TITLE
Add edith agent

### DIFF
--- a/edith/agent.json
+++ b/edith/agent.json
@@ -1,0 +1,39 @@
+{
+  "id": "edith",
+  "name": "EDITH",
+  "version": "0.2.1",
+  "description": "A local coding agent for your project directory",
+  "repository": "https://github.com/lucy971326/EDITH",
+  "authors": [
+    "Lucy"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/lucy971326/EDITH/releases/download/v0.2.1/edith-darwin-arm64",
+        "sha256": "8a69e2a764f3a838e94593217d6f51337e9f1179e2beb1a1141784d2d9dbe0ae",
+        "cmd": "./edith-darwin-arm64",
+        "args": ["acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/lucy971326/EDITH/releases/download/v0.2.1/edith-darwin-amd64",
+        "sha256": "3b0aafad5b6b0d904efd025e1a27391dfa4fc389f21412f0c631c3b1dbbb9e9a",
+        "cmd": "./edith-darwin-amd64",
+        "args": ["acp"]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/lucy971326/EDITH/releases/download/v0.2.1/edith-linux-amd64",
+        "sha256": "ba49e83e590a6f06bf3b6e14033e13f1345de252f6b09ba71a75973af93c6d0a",
+        "cmd": "./edith-linux-amd64",
+        "args": ["acp"]
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/lucy971326/EDITH/releases/download/v0.2.1/edith-windows-amd64.exe",
+        "sha256": "6f145d69b43eb7f90164b00ce38f0ea4b01fd4404c068e5cf8a1f5e3e49f72e1",
+        "cmd": "edith-windows-amd64.exe",
+        "args": ["acp"]
+      }
+    }
+  }
+}

--- a/edith/icon.svg
+++ b/edith/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 256 256">
+  <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="22">
+    <path d="M77 105 C72 78 82 50 108 36 C135 21 163 31 175 56 C188 83 175 111 143 137"/>
+    <path d="M48 121 C78 103 119 97 160 103 C199 109 222 132 220 160 C218 187 194 204 168 204"/>
+    <path d="M83 129 C91 158 110 185 139 198 C165 210 193 202 211 181"/>
+    <path d="M126 189 C106 205 78 216 53 208 C27 200 16 177 26 153 C39 122 70 108 111 106"/>
+  </g>
+</svg>


### PR DESCRIPTION
Add EDITH, a local coding agent for the project directory.

- Binary distribution for macOS (arm64/x64), Linux x64, and Windows x64
- Launch with `edith acp`
- Source: https://github.com/lucy971326/EDITH
- Release: https://github.com/lucy971326/EDITH/releases/tag/v0.2.1