### PR TITLE
Update agent-vesper to v0.20.48

### DIFF
--- a/agent-vesper/agent.json
+++ b/agent-vesper/agent.json
@@ -1,0 +1,36 @@
+{
+  "id": "agent-vesper",
+  "name": "Agent Vesper",
+  "version": "0.20.48",
+  "description": "Agent Vesper \u2014 a Rust-native ACP coding-agent runtime featuring the Vesper Reasoning Orchestrator (VRO), transactional sessions, hosted tools, provider-routed authentication, and a mem0-equivalent cognitive memory engine. The release bundle includes a native TUI with visible global/project memory routing, explicit scope overrides, a two-scope audit view, and verified promote/demote lifecycle controls. The ACP v1 stdio server currently ships the real Z.ai GLM adapter on a provider-neutral architecture, installable in Zed and other ACP-compatible editors.",
+  "repository": "https://github.com/99percentgrip/agent-vesper",
+  "website": "https://github.com/99percentgrip/agent-vesper",
+  "authors": [
+    "Aleksejs Kozlitins"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "binary": {
+      "darwin-x86_64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.46/agent-vesper-acp-darwin-x86_64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "darwin-aarch64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.46/agent-vesper-acp-darwin-aarch64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.46/agent-vesper-acp-linux-x86_64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.46/agent-vesper-acp-linux-aarch64.tar.gz",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp"
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/99percentgrip/agent-vesper/releases/download/v0.20.46/agent-vesper-acp-windows-x86_64.zip",
+        "cmd": "./agent-vesper-acp/agent-vesper-acp.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bumps Agent Vesper to [v0.20.48](https://github.com/99percentgrip/agent-vesper/releases/tag/v0.20.48).

## Changes in v0.20.48
- Learned-skill store raised to 200 KB / 500 files, enabling curated reference skill libraries.
- New cross-project global read layer for skills (project-local slugs shadow global ones; `AGENT_VESPER_GLOBAL_MEMORY_ROOT` override).
- `read_skill` section reads for large skills and oracle-parity `list_skills` headlines (frontmatter `description` preferred).

## Manifest
- `version` and all five platform archive URLs updated to v0.20.48; everything else unchanged from #534.

Verified: 5-platform CI + MSRV 1.88 + supply-chain green on merge commit 82a13a5; release binaries published and installer-verified locally.