### PR TITLE
Add agentty

### DIFF
--- a/agentty/agent.json
+++ b/agentty/agent.json
@@ -1,0 +1,44 @@
+{
+  "id": "agentty",
+  "name": "agentty",
+  "version": "0.3.0",
+  "description": "A fast, terminal-native coding agent with live tool cards, streaming reasoning, subagents, MCP plugins, skills, and hooks. Works standalone (TUI) or as an ACP agent in any editor.",
+  "repository": "https://github.com/1ay1/agentty",
+  "website": "https://github.com/1ay1/agentty",
+  "authors": ["1ay1 <tfeayush@gmail.com>"],
+  "license": "Apache-2.0",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/1ay1/agentty/releases/download/v0.3.0/agentty-macos-arm64",
+        "sha256": "d1a7c101b616400dcbd0b7ca7d04166bac482166e03bac9bb2f83eae5ae33660",
+        "cmd": "./agentty-macos-arm64",
+        "args": ["acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/1ay1/agentty/releases/download/v0.3.0/agentty-macos-x86_64",
+        "sha256": "58141bc9aff459444e1cf9926cc1f4d8806b254538485d81fa79b0e006ab9336",
+        "cmd": "./agentty-macos-x86_64",
+        "args": ["acp"]
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/1ay1/agentty/releases/download/v0.3.0/agentty-linux-aarch64",
+        "sha256": "00913d82ec457e906f300f9df9b3a7b94076a4abb6ba95c4e35be1dd2aefc3ac",
+        "cmd": "./agentty-linux-aarch64",
+        "args": ["acp"]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/1ay1/agentty/releases/download/v0.3.0/agentty-linux-x86_64",
+        "sha256": "b4058aac4249c928ae16ffd05bf98a11a1cb32f9ae35f6fbdd3cb9b954bc74bf",
+        "cmd": "./agentty-linux-x86_64",
+        "args": ["acp"]
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/1ay1/agentty/releases/download/v0.3.0/agentty-windows-x86_64.exe",
+        "sha256": "124540206c55a8ef93707a524f3f67f0b1ca0c6fa9adaefea457bf9637222e4c",
+        "cmd": "agentty-windows-x86_64.exe",
+        "args": ["acp"]
+      }
+    }
+  }
+}

--- a/agentty/icon.svg
+++ b/agentty/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M3 4.5 L6 8 L3 11.5"/>
+  <path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M8 11.5 H13"/>
+</svg>


### PR DESCRIPTION
Adds **agentty** — a fast, terminal-native coding agent that works standalone (TUI) or as an ACP agent in any editor.

## Agent

- **Repository:** https://github.com/1ay1/agentty
- **ACP command:** `agentty acp`
- **License:** Apache-2.0

## Distribution

Binary distribution for all six targets, pinned to the `v0.3.0` GitHub release assets with sha256 checksums:

| platform | asset |
|----------|-------|
| darwin-aarch64 | agentty-macos-arm64 |
| darwin-x86_64 | agentty-macos-x86_64 |
| linux-aarch64 | agentty-linux-aarch64 |
| linux-x86_64 | agentty-linux-x86_64 |
| windows-x86_64 | agentty-windows-x86_64.exe |

## Auth

agentty's ACP server advertises the `agentty-login` auth method in the `initialize` handshake when no credentials are present, satisfying the registry's authentication requirement. Verified against a clean environment:

```
initialize → protocolVersion 1, agentInfo {agentty, 0.3.0},
             authMethods [{ id: agentty-login, name: "Sign in to agentty", type: agent }]
```

## Notes

- The entry validates against `agent.schema.json` and is accepted by `build_registry.py` locally ("Added agent: agentty v0.3.0").
- Icon is 16×16 monochrome using `currentColor`.
- Same release assets power agentty's own self-update, so the registry's hourly version cron will track future `v*` releases automatically.