### PR TITLE
feat: add hermes-agent

### DIFF
--- a/hermes-agent/agent.json
+++ b/hermes-agent/agent.json
@@ -1,0 +1,16 @@
+{
+  "id": "hermes-agent",
+  "name": "Hermes Agent",
+  "version": "0.19.0",
+  "description": "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere",
+  "repository": "https://github.com/NousResearch/hermes-agent",
+  "website": "https://hermes-agent.nousresearch.com",
+  "authors": ["Nous Research"],
+  "license": "MIT",
+  "distribution": {
+    "uvx": {
+      "package": "hermes-agent[acp]==0.19.0",
+      "args": ["hermes-acp"]
+    }
+  }
+}

--- a/hermes-agent/icon.svg
+++ b/hermes-agent/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 1C4.7 1 2 3.7 2 7s2.7 6 6 6 6-2.7 6-6-2.7-6-6-6zm0 1.5c.8 0 1.5.7 1.5 1.5S8.8 5.5 8 5.5 6.5 4.8 6.5 4 7.2 2.5 8 2.5zM6 7h4v1H7v1h2v1H7v2H6V7z"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds [Hermes Agent](https://github.com/NousResearch/hermes-agent) to the ACP registry.

### About Hermes Agent

Hermes Agent is a self-improving AI agent by [Nous Research](https://nousresearch.com). It features:

- **Native ACP support** via the `acp_adapter` module (entry point: `hermes-acp`)
- **Terminal Auth** — interactive `--setup` flow for first-time provider configuration
- **Agent Auth** — uses configured runtime credentials (OpenRouter, OpenAI, etc.)
- Multi-provider model support (OpenRouter, OpenAI, Anthropic, local endpoints, and 20+ others)
- Cross-platform: Linux, macOS, Windows, Termux
- Self-improving skills, memory, subagent delegation, scheduled automations

### Distribution

- **PyPI**: `hermes-agent[acp]` (includes `agent-client-protocol` dependency)
- **Entry point**: `hermes-acp` (runs the ACP adapter server over stdio)
- **Version**: 0.19.0 (auto-updates from PyPI)

### Authentication

Hermes supports both required auth methods:

1. **Agent Auth** — when provider credentials are configured, advertises the resolved provider (e.g., `openrouter`) as an agent-managed auth method
2. **Terminal Auth** — always advertised as `hermes-setup` with `args: ["--setup"]`, launches interactive model/provider setup

### Files

- `hermes-agent/agent.json` — registry entry
- `hermes-agent/icon.svg` — 16x16 monochrome icon

Closes NousResearch/hermes-agent#9111