### PR TITLE
Add Chutes Agent

### DIFF
--- a/chutes/agent.json
+++ b/chutes/agent.json
@@ -1,0 +1,17 @@
+{
+  "id": "chutes",
+  "name": "Chutes Agent",
+  "version": "0.1.0",
+  "description": "Coding agent powered by Chutes.ai models (DeepSeek, Qwen, GLM, Kimi, …) with file editing, shell tools, and a live model picker",
+  "repository": "https://github.com/heyalbert/zed-chutes-agent",
+  "website": "https://chutes.ai",
+  "authors": [
+    "Albert (heyalbert)"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "chutes-agent@0.1.0"
+    }
+  }
+}

--- a/chutes/icon.svg
+++ b/chutes/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+  <path d="M8 1C3.9 1 0.8 3.6 0.8 6.6V7.1H15.2V6.6C15.2 3.6 12.1 1 8 1Z"/>
+  <path d="M2.1 7.7L3 7.7L8.1 12.6L7.4 13.2Z"/>
+  <path d="M13.9 7.7L13 7.7L7.9 12.6L8.6 13.2Z"/>
+  <rect x="6.6" y="12.7" width="2.8" height="2.5" rx="0.6"/>
+</svg>


### PR DESCRIPTION
## Add Chutes Agent

A coding agent powered by [Chutes.ai](https://chutes.ai) models (DeepSeek, Qwen, GLM, Kimi, …), speaking ACP over stdio.

- **Repository:** https://github.com/heyalbert/zed-chutes-agent
- **Distribution:** npm — [`chutes-agent@0.1.0`](https://www.npmjs.com/package/chutes-agent)
- **License:** MIT

### Features

- Any tool-capable Chutes model, with a live model picker (session config options) populated from the Chutes catalog
- File read/edit/write with diffs, directory listing, and shell commands in embedded terminals, gated behind permission prompts
- Streams reasoning as thought chunks for reasoning models

### Authentication

`initialize` returns two auth methods:

- `terminal` (`chutes-login`, advertised when the client sets `auth.terminal`): runs `chutes-agent --login`, which prompts for an API key, validates it against the Chutes API, and saves it locally (0600)
- `agent` (`chutes-api-key`): default method; `authenticate` succeeds when a key is present via `CHUTES_API_KEY` or the saved login, and returns `auth_required` with instructions otherwise

Verified locally: `build_registry.py` passes (`Added agent: chutes v0.1.0`), and `npx chutes-agent@0.1.0` completes the initialize handshake with `authMethods` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)