### PR TITLE
Correct the glm-acp-agent model list

### DIFF
--- a/glm-acp-agent/agent.json
+++ b/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.6.1",
-  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Z.AI / Zhipu AI GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": [
     "Stefan de Vogelaere"


### PR DESCRIPTION
### What

Corrects the `glm-acp-agent` description, which advertises two models the agent no longer serves under those names.

### Why

The description lists `glm-5.1` and `glm-4.5-air`. Neither is served under its own name any more — the Z.AI Coding Plan endpoint routes a request for `glm-5.1` to `glm-5.3`, and `glm-4.5-air` to `glm-4.7`. A client picking either from the registry would be told it is talking to a model it is not. The advertised list is now `glm-5.3`, `glm-5-turbo`, `glm-4.7`, matching what the agent actually returns in `availableModels`.

Also adds `thought_level` (reasoning effort) config, supported for several releases but never reflected here.

Description-only diff — the version cron bumped this entry to 1.6.1 while the PR was open, so that line is now untouched.

### Validation

Run from the repo root, all passing:

- `uv run --with jsonschema .github/workflows/build_registry.py`
- `SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py`
- `python3 .github/workflows/verify_agents.py --auth-check --agent glm-acp-agent` → `Auth OK: z-ai-api-key(agent), z_ai_api_key(env_var)`

`icon.svg` is intentionally untouched.