### PR TITLE
Add Spirit

### DIFF
--- a/spirit/agent.json
+++ b/spirit/agent.json
@@ -1,0 +1,17 @@
+{
+  "id": "spirit",
+  "name": "Spirit",
+  "version": "0.3.3",
+  "description": "An open-source AI agent built to multiply your productivity.",
+  "repository": "https://github.com/SpiritAgents/spirit",
+  "website": "https://spirit.fast",
+  "authors": [
+    "N123999"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "npx": {
+      "package": "@spiritagent/acp-server@0.3.3"
+    }
+  }
+}

--- a/spirit/icon.svg
+++ b/spirit/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 142 157">
+  <path fill="currentColor" d="M0 0L141.409 69.4512L70.7825 78.2408C61.5778 79.3863 53.5378 85.016 49.3132 93.2737L16.8979 156.635L0 0Z"/>
+</svg>


### PR DESCRIPTION
Adds **Spirit**, an open-source AI agent with an ACP server adapter for editor integration.

Supersedes #389 — same project, rebranded from Spirit Agent to Spirit (new repo: `SpiritAgents/spirit`).

- `spirit/agent.json` — npx distribution via `@spiritagent/acp-server@0.3.3`
- `spirit/icon.svg` — 16×16, `currentColor`
- **Authentication:** `initialize` advertises `type: "terminal"`
- **Repository:** https://github.com/SpiritAgents/spirit
- **Website:** https://spirit.fast