### PR TITLE
Add Lenso Agent

### DIFF
--- a/lenso/agent.json
+++ b/lenso/agent.json
@@ -1,0 +1,25 @@
+{
+  "id": "lenso",
+  "name": "Lenso Agent",
+  "version": "0.1.0",
+  "description": "A local coding Agent with replaceable Lenso Plugins",
+  "repository": "https://github.com/LioRael/lenso-agent",
+  "authors": [
+    "Lenso contributors"
+  ],
+  "license": "MIT",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/LioRael/lenso-agent/releases/download/v0.1.0/lenso-agent-acp-v0.1.0-darwin-aarch64.tar.gz",
+        "sha256": "138da6c4ef38b7a51e1faee3e8cac5969be5efbe29fd52f0b02aaf41b5e414dc",
+        "cmd": "./lenso-agent-acp"
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/LioRael/lenso-agent/releases/download/v0.1.0/lenso-agent-acp-v0.1.0-linux-x86_64.tar.gz",
+        "sha256": "7aeee7255bcd5a868ad6d734762f6594ae28b4115ff1f8f12cd81ca36845b901",
+        "cmd": "./lenso-agent-acp"
+      }
+    }
+  }
+}

--- a/lenso/icon.svg
+++ b/lenso/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path fill="currentColor" d="M3 2h3v9h7v3H3V2Zm5 0h5v3H8V2Zm0 5h5v3H8V7Z"/>
+</svg>


### PR DESCRIPTION
## Summary

- register Lenso Agent v0.1.0 from its published GitHub release
- provide checksum-pinned ACP archives for Apple silicon macOS 15+ and Linux x86_64
- add a 16x16 monochrome `currentColor` icon

Windows is not published in this first release; the registry validator reports that as a non-blocking coverage warning.

## Validation

- `SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py`
- direct unauthenticated ranged GETs returned HTTP 206 for both archive URLs
- `python3 .github/workflows/verify_agents.py --auth-check --agent lenso` — passed (`chatgpt(agent)`)
- `uv run --with pytest pytest tests/ -v` — 121 passed
- `uv run --with ruff ruff check .`
- `uv run --with ruff ruff format --check .`
- release assets verified against `SHA256SUMS` and GitHub build provenance