### PR TITLE
Add license/ToC URLs

### DIFF
--- a/agent.schema.json
+++ b/agent.schema.json
@@ -47,6 +47,11 @@
       "type": "string",
       "description": "SPDX license identifier or 'proprietary'"
     },
+    "license_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to the license text or terms of service"
+    },
     "icon": {
       "type": "string",
       "description": "Icon URL (set automatically by the build from the required icon.svg file)"

--- a/agoragentic-acp/agent.json
+++ b/agoragentic-acp/agent.json
@@ -7,6 +7,7 @@
   "website": "https://agoragentic.com",
   "authors": ["ACRE / Agoragentic"],
   "license": "MIT",
+  "license_url": "https://github.com/rhein1/agoragentic-integrations/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "agoragentic-mcp@1.3.0",

--- a/amp-acp/agent.json
+++ b/amp-acp/agent.json
@@ -8,6 +8,7 @@
     "tao12345666333"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/tao12345666333/amp-acp/blob/main/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "binary": {

--- a/auggie/agent.json
+++ b/auggie/agent.json
@@ -9,6 +9,7 @@
     "Augment Code <support@augmentcode.com>"
   ],
   "license": "proprietary",
+  "license_url": "https://github.com/augmentcode/auggie/blob/main/LICENSE.md",
   "icon": "./icon.svg",
   "distribution": {
     "npx": {

--- a/autohand/agent.json
+++ b/autohand/agent.json
@@ -7,6 +7,7 @@
   "website": "https://www.autohand.ai/cli/",
   "authors": ["Autohand AI"],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/autohandai/autohand-acp/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "@autohandai/autohand-acp@0.2.1"

--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -10,6 +10,7 @@
     "JetBrains"
   ],
   "license": "proprietary",
+  "license_url": "https://github.com/agentclientprotocol/claude-agent-acp/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "@agentclientprotocol/claude-agent-acp@0.70.0"

--- a/cline/agent.json
+++ b/cline/agent.json
@@ -9,6 +9,7 @@
     "Cline Bot Inc."
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/cline/cline/blob/main/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "npx": {

--- a/codex-acp/agent.json
+++ b/codex-acp/agent.json
@@ -10,6 +10,7 @@
     "Zed Industries"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/agentclientprotocol/codex-acp/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "@agentclientprotocol/codex-acp@1.7.0"

--- a/corust-agent/agent.json
+++ b/corust-agent/agent.json
@@ -9,6 +9,7 @@
     "Corust AI <support@corust.ai>"
   ],
   "license": "GPL-3.0-or-later",
+  "license_url": "https://github.com/Corust-ai/corust-agent-release/blob/main/LICENSE",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/crow-cli/agent.json
+++ b/crow-cli/agent.json
@@ -9,6 +9,7 @@
     "Thomas Wood"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/crow-cli/crow-cli/blob/main/LICENSE.md",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/cursor/agent.json
+++ b/cursor/agent.json
@@ -6,6 +6,7 @@
   "website": "https://cursor.com/docs/cli/acp",
   "authors": ["Cursor"],
   "license": "proprietary",
+  "license_url": "https://cursor.com/terms-of-service",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/deepagents/agent.json
+++ b/deepagents/agent.json
@@ -9,6 +9,7 @@
     "LangChain"
   ],
   "license": "MIT",
+  "license_url": "https://github.com/langchain-ai/deepagentsjs/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "deepagents-acp@0.1.7",

--- a/dirac/agent.json
+++ b/dirac/agent.json
@@ -9,6 +9,7 @@
     "Dirac Delta Labs"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/dirac-run/dirac/blob/master/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "npx": {

--- a/fast-agent/agent.json
+++ b/fast-agent/agent.json
@@ -9,6 +9,7 @@
     "enquiries@fast-agent.ai"
   ],
   "license": "Apache 2.0",
+  "license_url": "https://github.com/evalstate/fast-agent/blob/main/LICENSE",
   "distribution": {
     "uvx": {
       "package": "fast-agent-acp==0.10.1",

--- a/gemini/agent.json
+++ b/gemini/agent.json
@@ -9,6 +9,7 @@
     "Google"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/google-gemini/gemini-cli/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "@google/gemini-cli@0.57.0",

--- a/github-copilot/agent.json
+++ b/github-copilot/agent.json
@@ -9,6 +9,7 @@
     "GitHub"
   ],
   "license": "proprietary",
+  "license_url": "https://github.com/github/copilot-language-server-release/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "@github/copilot-language-server@1.537.1",

--- a/glm-acp-agent/agent.json
+++ b/glm-acp-agent/agent.json
@@ -8,6 +8,7 @@
     "Stefan de Vogelaere"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/stefandevo/glm-acp-agent/blob/main/LICENSE",
   "icon": "icon.svg",
   "distribution": {
     "npx": {

--- a/goose/agent.json
+++ b/goose/agent.json
@@ -9,6 +9,7 @@
     "Block"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/block/goose/blob/main/LICENSE",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/harn/agent.json
+++ b/harn/agent.json
@@ -9,6 +9,7 @@
     "Burin Labs"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/burin-labs/harn/blob/main/LICENSE-APACHE",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/kilo/agent.json
+++ b/kilo/agent.json
@@ -9,6 +9,7 @@
     "Kilo Code"
   ],
   "license": "MIT",
+  "license_url": "https://github.com/Kilo-Org/kilocode/blob/main/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "binary": {

--- a/kimi/agent.json
+++ b/kimi/agent.json
@@ -9,6 +9,7 @@
     "Moonshot AI"
   ],
   "license": "MIT",
+  "license_url": "https://github.com/MoonshotAI/kimi-cli/blob/main/LICENSE",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/minion-code/agent.json
+++ b/minion-code/agent.json
@@ -8,6 +8,7 @@
     "femto"
   ],
   "license": "AGPL-3.0",
+  "license_url": "https://github.com/femto/minion-code/blob/main/LICENSE",
   "distribution": {
     "uvx": {
       "package": "minion-code@0.1.44",

--- a/mistral-vibe/agent.json
+++ b/mistral-vibe/agent.json
@@ -9,6 +9,7 @@
     "Mistral AI"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/mistralai/mistral-vibe/blob/main/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "binary": {

--- a/nova/agent.json
+++ b/nova/agent.json
@@ -9,6 +9,7 @@
     "Compass AI"
   ],
   "license": "proprietary",
+  "license_url": "https://github.com/Compass-Agentic-Platform/nova/blob/main/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "npx": {

--- a/opencode/agent.json
+++ b/opencode/agent.json
@@ -9,6 +9,7 @@
     "Anomaly"
   ],
   "license": "MIT",
+  "license_url": "https://github.com/anomalyco/opencode/blob/dev/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "binary": {

--- a/pi-acp/agent.json
+++ b/pi-acp/agent.json
@@ -8,6 +8,7 @@
     "Sergii Kozak <svkozak@gmail.com>"
   ],
   "license": "MIT",
+  "license_url": "https://github.com/svkozak/pi-acp/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "pi-acp@0.0.33"

--- a/poolside/agent.json
+++ b/poolside/agent.json
@@ -9,6 +9,7 @@
     "Poolside <feedback@poolside.ai>"
   ],
   "license": "proprietary",
+  "license_url": "https://github.com/poolsideai/pool/blob/main/LICENSE.md",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/qwen-code/agent.json
+++ b/qwen-code/agent.json
@@ -9,6 +9,7 @@
     "Alibaba Qwen Team"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/QwenLM/qwen-code/blob/main/LICENSE",
   "distribution": {
     "npx": {
       "package": "@qwen-code/qwen-code@0.22.3",

--- a/sigit/agent.json
+++ b/sigit/agent.json
@@ -9,6 +9,7 @@
     "smbCloud"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/getsigit/sigit/blob/main/LICENSE",
   "distribution": {
     "binary": {
       "darwin-aarch64": {

--- a/stakpak/agent.json
+++ b/stakpak/agent.json
@@ -9,6 +9,7 @@
     "Stakpak Team <contact@stakpak.dev>"
   ],
   "license": "Apache-2.0",
+  "license_url": "https://github.com/stakpak/agent/blob/main/LICENSE",
   "icon": "./icon.svg",
   "distribution": {
     "binary": {

--- a/vtcode/agent.json
+++ b/vtcode/agent.json
@@ -7,6 +7,7 @@
   "website": "https://github.com/vinhnx/VTCode/blob/main/docs/guides/zed-acp.md",
   "authors": ["vinhnx"],
   "license": "MIT",
+  "license_url": "https://github.com/vinhnx/VTCode/blob/main/LICENSE",
   "distribution": {
     "binary": {
       "darwin-aarch64": {


### PR DESCRIPTION
We have to follow legal requirements to show license or ToC for every 3rd party software (agents from ACP registry included), so the goal of this PR is to add them into the registry.json 