### PR TITLE
Add Clio Coder

### DIFF
--- a/clio-coder/agent.json
+++ b/clio-coder/agent.json
@@ -1,0 +1,21 @@
+{
+  "id": "clio-coder",
+  "name": "Clio Coder",
+  "version": "0.4.0",
+  "description": "Coding agent for HPC and scientific-software developers, part of IOWarp's CLIO ecosystem",
+  "repository": "https://github.com/iowarp/clio-coder",
+  "website": "https://iowarp.ai",
+  "authors": [
+    "Anthony Kougkas <a.kougkas@gmail.com>",
+    "IOWarp <https://iowarp.ai>"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "npx": {
+      "package": "@iowarp/clio-coder@0.4.0",
+      "args": [
+        "acp"
+      ]
+    }
+  }
+}

--- a/clio-coder/icon.svg
+++ b/clio-coder/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M13.25 4.25A5.25 5.25 0 1 0 13.25 11.75" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M1.75 4.75 5 8l-3.25 3.25M5 8h7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

- add Clio Coder as an ACP agent
- launch the published 0.4.0 package through its canonical `acp` subcommand
- advertise the `clio-login` terminal authentication flow
- include a 16x16 currentColor icon

## Validation

- registry dry run passes with URL validation enabled
- registry auth verification passes for clio-coder
- published package reports terminal auth args: `auth login`