### PR TITLE
Add muse-acp

### DIFF
--- a/muse-acp/agent.json
+++ b/muse-acp/agent.json
@@ -1,0 +1,17 @@
+{
+  "id": "muse-acp",
+  "name": "Muse",
+  "version": "0.1.0",
+  "description": "ACP adapter for Muse Code",
+  "repository": "https://github.com/sanjay3290/muse-acp",
+  "website": "https://github.com/sanjay3290/muse-acp#readme",
+  "authors": [
+    "sanjay3290"
+  ],
+  "license": "Apache-2.0",
+  "distribution": {
+    "npx": {
+      "package": "muse-acp@0.1.0"
+    }
+  }
+}

--- a/muse-acp/icon.svg
+++ b/muse-acp/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M2 13V3h1.9l2.6 6.1L9.1 3H11v10H9.4V6.2L7.1 11.6H5.9L3.6 6.2V13H2z"/>
+  <path fill="currentColor" d="M12.6 3H14v6.6c0 1.1-.3 1.9-.9 2.5-.6.6-1.4.9-2.4.9v-1.5c.6 0 1.1-.2 1.4-.5.3-.3.5-.8.5-1.4V3z"/>
+</svg>


### PR DESCRIPTION
I added `muse-acp` so ACP clients can discover and launch Muse Code from the registry.

The adapter bridges ACP to Muse Session Protocol over stdio. One `muse serve` process handles multiple sessions.

- Repository: [sanjay3290/muse-acp](https://github.com/sanjay3290/muse-acp), Apache-2.0.
- Package: [muse-acp](https://www.npmjs.com/package/muse-acp).
- Protocol layer: `@agentclientprotocol/sdk` 1.4.0.
- Features: session creation, load, prompts, cancellation, session list, streamed updates, and tool permission requests.
- Multi-stage shell approvals are supported through a documented vendor patch.

### Source fixes and validation

I pushed [0835abe](https://github.com/sanjay3290/muse-acp/commit/0835abea9a1b3ba5ec6f8c269d51a48e1684f4da) with these fixes:

- Preserve turn failures as errors and drain buffered output before the prompt response.
- Preserve image bytes and replay conversation history on session load.
- Honour binary overrides and retain discovery for clients with a restricted PATH.
- Handle early cancellation, concurrent prompts, and delayed client updates.
- Forward session MCP configuration only when the Muse host grants `sessionMcp`.

All 70 automated tests, the type check, and the build pass. The package dry run also passes.

I tested the built ACP process against Muse Code 1.2.1. Text, image recognition, model selection, session restore, cancellation, and cancellation recovery passed. A separate live check confirmed that host disconnects return errors.

Two limits remain:

- Muse 1.2.1 does not grant `sessionMcp`. A direct probe accepted MCP configuration but did not expose the test tool. The adapter now rejects unsupported MCP requests explicitly.
- A later live repeat stalled while Muse tried to open a model stream after session restore. The watchdog returned an error after 120 seconds. The live suite is not consistently green.

### Package status

This registry entry still pins `muse-acp@0.1.0`, published on September 1, 2026. That package predates the fixes above. I have not published a new npm version yet. The registry version and package pin need an update after that release.

The original registry entry passed `build_registry.py --dry-run` with `Added agent: muse-acp v0.1.0`.
