### PR TITLE
Update Google Antigravity agent to 1.1.1

### DIFF
--- a/antigravity-acp/agent.json
+++ b/antigravity-acp/agent.json
@@ -1,35 +1,36 @@
 {
   "id": "antigravity-acp",
   "name": "Google Antigravity",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Google’s AI coding agent",
   "website": "https://antigravity.google/docs/ide/extensions",
   "authors": [
     "Google LLC"
   ],
   "license": "proprietary",
+  "license_url": "https://antigravity.google/terms",
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://dl.google.com/agy-extensions/releases/macos/agy-acp-server-agy_acp_server_20260818_01_RC01-darwin-arm64.zip",
+        "archive": "https://dl.google.com/agy-extensions/releases/macos/agy-acp-server-agy_acp_server_1.1.1-darwin-arm64.zip",
         "cmd": "./agy_acp_server.par"
       },
       "linux-x86_64": {
-        "archive": "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_20260818_01_RC01-linux-x86_64.zip",
+        "archive": "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_1.1.1-linux-x86_64.zip",
         "cmd": "./agy_acp_server.par",
         "args": ["--uid="]
       },
       "linux-aarch64": {
-        "archive": "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_20260818_01_RC01-linux-arm64.zip",
+        "archive": "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_1.1.1-linux-arm64.zip",
         "cmd": "./agy_acp_server.par",
         "args": ["--uid="]
       },
       "windows-x86_64": {
-        "archive": "https://dl.google.com/agy-extensions/releases/windows/agy-acp-server-agy_acp_server_20260818_01_RC01-windows-x86_64.zip",
+        "archive": "https://dl.google.com/agy-extensions/releases/windows/agy-acp-server-agy_acp_server_1.1.1-windows-x86_64.zip",
         "cmd": "./agy_acp_server.exe"
       },
       "windows-aarch64": {
-        "archive": "https://dl.google.com/agy-extensions/releases/windows/agy-acp-server-agy_acp_server_20260818_01_RC01-windows-arm64.zip",
+        "archive": "https://dl.google.com/agy-extensions/releases/windows/agy-acp-server-agy_acp_server_1.1.1-windows-arm64.zip",
         "cmd": "./agy_acp_server.exe"
       }
     }


### PR DESCRIPTION
Updates `antigravity-acp` distribution binaries to version 1.1.1 across all supported platforms.