### PR TITLE
Add Kit agent

### DIFF
--- a/kit/agent.json
+++ b/kit/agent.json
@@ -1,0 +1,32 @@
+{
+  "id": "kit",
+  "name": "Kit",
+  "version": "0.1.125",
+  "description": "A coding agent runtime with one composable tool, reusable subagents, and open protocol support",
+  "repository": "https://github.com/speakeasy-api/kit",
+  "authors": [
+    "Speakeasy"
+  ],
+  "license": "MIT",
+  "license_url": "https://github.com/speakeasy-api/kit/blob/main/LICENSE",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/speakeasy-api/kit/releases/download/v0.1.125/kit-v0.1.125-aarch64-apple-darwin.tar.gz",
+        "sha256": "9952aca1316dc13061ba978ec70f4dd252a0a7ca00a0f0b8b0d01e243e29b4f2",
+        "cmd": "./kit",
+        "args": [
+          "acp"
+        ]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/speakeasy-api/kit/releases/download/v0.1.125/kit-v0.1.125-x86_64-unknown-linux-gnu.tar.gz",
+        "sha256": "09fa9673ce7378da5bd9c504c77ef47546399b4ec820fc89db43cf9eb4d03772",
+        "cmd": "./kit",
+        "args": [
+          "acp"
+        ]
+      }
+    }
+  }
+}

--- a/kit/icon.svg
+++ b/kit/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="300 300 424 424">
+  <path fill="currentColor" d="M341.756 660.09h26.233v-78.7l22.849-21.579 89.701 100.279h36.388L409.455 542.886l91.817-86.317h-33.85l-79.123 75.316-20.31 19.04V363.906h-26.233z"/>
+  <path fill="currentColor" d="M559.24 406.22h123v253.87h-123z"/>
+</svg>


### PR DESCRIPTION
## Summary

Add Kit v0.1.125 to the ACP Registry with macOS Apple Silicon and Linux x86-64 binary distributions. Include pinned release checksums, the ACP startup command, project metadata, and a monochrome 16×16 icon.
