### PR TITLE
Add Oh My Pi (omp) with built-in ACP

### DIFF
--- a/omp/agent.json
+++ b/omp/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "omp",
+  "name": "Oh My Pi",
+  "version": "18.1.9",
+  "description": "Coding agent with built-in ACP: subagents, plan mode, LSP, DAP, and editor-bridged tools",
+  "repository": "https://github.com/can1357/oh-my-pi",
+  "website": "https://omp.sh/docs/acp",
+  "authors": [
+    "Stencil Labs, Inc.",
+    "Can Boluk"
+  ],
+  "license": "MIT",
+  "license_url": "https://github.com/can1357/oh-my-pi/blob/main/LICENSE",
+  "distribution": {
+    "npx": {
+      "package": "@oh-my-pi/pi-coding-agent@18.1.9",
+      "args": ["acp"]
+    }
+  }
+}

--- a/omp/icon.svg
+++ b/omp/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M2 3h12v2H10v9H8V5H7v7H5V5H2z"/>
+</svg>


### PR DESCRIPTION
Adds [Oh My Pi](https://omp.sh) (`omp`) to the ACP registry so Zed and other ACP clients can install it from the registry instead of a hand-written custom agent.

This is **not** a new adapter. Oh My Pi already ships a built-in ACP server:

```
omp acp
```

which is equivalent to:

```
npx -y @oh-my-pi/pi-coding-agent@18.1.9 acp
```

## Why this PR

- Registry currently has `pi-acp` (upstream Pi via a third-party adapter). It does **not** list Oh My Pi.
- Open PRs [#301](https://github.com/agentclientprotocol/registry/pull/301) (`omp-acp`, 15.9.0) and [#502](https://github.com/agentclientprotocol/registry/pull/502) (`omp`, 17.3.3) are stale. This one pins the current npm release **18.1.9** and uses the upstream built-in ACP command.

## Distribution

- **id:** `omp`
- **name:** Oh My Pi
- **npx:** `@oh-my-pi/pi-coding-agent@18.1.9` with `args: ["acp"]`
- **source:** https://github.com/can1357/oh-my-pi
- **docs:** https://omp.sh/docs/acp
- **license:** MIT

Once merged, hourly version updates can pick up later npm releases.

## Authentication

`initialize` advertises Agent Auth:

```json
{
  "id": "agent",
  "name": "Use existing local credentials",
  "description": "Authenticate via the provider keys/OAuth state already configured under ~/.omp."
}
```

Verified locally against the installed `omp/18.1.9` binary:

```
initialize -> protocolVersion 1
agentInfo: { "name": "oh-my-pi", "title": "Oh My Pi", "version": "18.1.9" }
authMethods: [{ "id": "agent", "name": "Use existing local credentials", ... }]
```

This matches `AUTHENTICATION.md` (Agent Auth, `type` defaults to `agent`).

## Validation

```
SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py --dry-run
```

passed and included `Added agent: omp v18.1.9`. Icon is a 16x16 monochrome `currentColor` π mark (upstream favicon uses a gradient, which the registry rejects).

After merge, Zed users can install Oh My Pi from `zed: acp registry` and start an external-agent thread without editing `settings.json`.