### PR TITLE
feat: set up preview versions monitoring and preview registry for JetBrains

### DIFF
--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run tests
         working-directory: .github/workflows
-        run: uv run --with pytest pytest tests/ -v
+        run: uv run --with pytest --with jsonschema pytest tests/ -v
 
   build:
     name: Build & Validate
@@ -234,6 +234,7 @@ jobs:
             --notes "$RELEASE_NOTES" \
             dist/registry.json \
             dist/registry-for-jetbrains.json \
+            dist/registry-for-jetbrains-preview.json \
             dist/agent.schema.json \
             dist/registry.schema.json \
             dist/*.svg

--- a/.github/workflows/build_registry.py
+++ b/.github/workflows/build_registry.py
@@ -16,11 +16,14 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from registry_utils import (
+    UVX_VERSION_PATTERN,
     extract_npm_package_name,
     extract_npm_package_version,
     extract_pypi_package_name,
     normalize_version,
+    resolve_preview_entry,
     should_skip_dir,
+    strip_preview,
 )
 
 try:
@@ -43,6 +46,10 @@ VALID_PLATFORMS = {
 }
 REQUIRED_OS_FAMILIES = {"darwin", "linux", "windows"}
 REJECTED_ARCHIVE_EXTENSIONS = (".dmg", ".pkg", ".deb", ".rpm", ".msi", ".appimage")
+
+# `preview.version` holds either an X.Y.Z-preview.N prerelease or, when the stable
+# channel has overtaken the preview line, a plain X.Y.Z release.
+PREVIEW_CHANNEL_VERSION_RE = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?")
 
 # Can be overridden via environment variable
 DEFAULT_BASE_URL = "https://cdn.agentclientprotocol.com/registry/v1/latest"
@@ -212,7 +219,7 @@ def validate_distribution_versions(agent_version: str, distribution: dict) -> li
             errors.append(f"uvx package uses '@latest' - use explicit version instead: {package}")
         # Extract version from uvx package
         # (formats: package==version, package>=version, package@version)
-        version_match = re.search(r"[=@]+([\d.]+)", package)
+        version_match = re.search(rf"[=@]+({UVX_VERSION_PATTERN})", package)
         if version_match:
             pkg_version = version_match.group(1)
             if pkg_version != agent_version:
@@ -438,6 +445,39 @@ def validate_against_schema(agent: dict, schema: dict) -> list[str]:
     return errors
 
 
+def validate_preview(agent: dict) -> list[str]:
+    """Validate the optional `preview` block.
+
+    Offline checks only. The preview channel is explicitly unverified: nothing
+    here touches the network. Allowed keys, distribution types and per-type
+    field shapes are enforced by agent.schema.json; the one check kept here is
+    that the package spec pins exactly `preview.version`. There is deliberately
+    no ordering constraint against the stable `version` - see resolve_preview_entry.
+    """
+    preview = agent.get("preview")
+    if preview is None:
+        return []
+    if not isinstance(preview, dict):
+        return ["Field 'preview' must be an object"]
+
+    errors = []
+
+    version = preview.get("version")
+    if not isinstance(version, str) or not PREVIEW_CHANNEL_VERSION_RE.fullmatch(version):
+        errors.append(f"Field 'preview.version' ({version}) must be X.Y.Z-preview.N or plain X.Y.Z")
+        version = None
+
+    distribution = preview.get("distribution")
+    if not isinstance(distribution, dict) or not distribution:
+        errors.append("Field 'preview.distribution' must be a non-empty object")
+    elif version is not None:
+        errors.extend(
+            f"preview: {error}" for error in validate_distribution_versions(version, distribution)
+        )
+
+    return errors
+
+
 def validate_agent(agent: dict, agent_dir: str, schema: dict | None = None) -> list[str]:
     """Validate agent.json and return list of errors."""
     errors = []
@@ -532,6 +572,9 @@ def validate_agent(agent: dict, agent_dir: str, schema: dict | None = None) -> l
                     if "package" not in pkg_dist:
                         errors.append(f"Distribution '{dist_type}' missing 'package' field")
 
+    # Validate the optional preview channel (offline checks only)
+    errors.extend(validate_preview(agent))
+
     return errors
 
 
@@ -598,13 +641,15 @@ def process_entry(
     return entry, []
 
 
-def build_registry(dry_run: bool = False):
+def build_registry(dry_run: bool = False, registry_dir: Path | None = None):
     """Build registry.json from agent directories.
 
     Args:
         dry_run: If True, validate and report what would be built without writing to dist/.
+        registry_dir: Registry root to scan (defaults to the repository root).
     """
-    registry_dir = Path(__file__).parent.parent.parent
+    if registry_dir is None:
+        registry_dir = Path(__file__).parent.parent.parent
     base_url = get_base_url()
     agents = []
     seen_ids = {}
@@ -644,7 +689,7 @@ def build_registry(dry_run: bool = False):
 
     # Agents excluded from registry.json (default registry)
     DEFAULT_EXCLUDE_IDS = {"github-copilot"}
-    default_agents = [a for a in agents if a["id"] not in DEFAULT_EXCLUDE_IDS]
+    default_agents = [strip_preview(a) for a in agents if a["id"] not in DEFAULT_EXCLUDE_IDS]
 
     # Agents excluded from registry-for-jetbrains.json
     JETBRAINS_EXCLUDE_IDS = {"github-copilot-cli"}
@@ -662,8 +707,27 @@ def build_registry(dry_run: bool = False):
         return patched
 
     jetbrains_agents = [
-        patch_agent_for_jetbrains(a) for a in agents if a["id"] not in JETBRAINS_EXCLUDE_IDS
+        patch_agent_for_jetbrains(strip_preview(a))
+        for a in agents
+        if a["id"] not in JETBRAINS_EXCLUDE_IDS
     ]
+
+    # Preview registry: a complete, drop-in replacement for the JetBrains registry
+    # where every previewed agent resolves to the highest of its two channels.
+    jetbrains_preview_agents = []
+    distinct_preview_ids = []
+    for a in agents:
+        if a["id"] in JETBRAINS_EXCLUDE_IDS:
+            continue
+        preview_entry = resolve_preview_entry(a)
+        if preview_entry["version"] != a["version"]:
+            distinct_preview_ids.append(a["id"])
+        jetbrains_preview_agents.append(patch_agent_for_jetbrains(preview_entry))
+
+    def preview_summary() -> str:
+        if not distinct_preview_ids:
+            return "identical to the stable JetBrains registry"
+        return f"ahead of stable: {', '.join(sorted(distinct_preview_ids))}"
 
     if dry_run:
         print(f"\nDry run: validated {len(agents)} agents successfully")
@@ -674,6 +738,10 @@ def build_registry(dry_run: bool = False):
         print(
             f"  registry-for-jetbrains.json would contain "
             f"{len(jetbrains_agents)} agents (excluded: {', '.join(sorted(JETBRAINS_EXCLUDE_IDS))})"
+        )
+        print(
+            f"  registry-for-jetbrains-preview.json would contain "
+            f"{len(jetbrains_preview_agents)} agents ({preview_summary()})"
         )
         return
 
@@ -696,6 +764,16 @@ def build_registry(dry_run: bool = False):
     jetbrains_output_path = dist_dir / "registry-for-jetbrains.json"
     with open(jetbrains_output_path, "w") as f:
         json.dump(jetbrains_registry, f, indent=2)
+        f.write("\n")
+
+    # Write registry-for-jetbrains-preview.json
+    jetbrains_preview_registry = {
+        "version": REGISTRY_VERSION,
+        "agents": jetbrains_preview_agents,
+    }
+    jetbrains_preview_output_path = dist_dir / "registry-for-jetbrains-preview.json"
+    with open(jetbrains_preview_output_path, "w") as f:
+        json.dump(jetbrains_preview_registry, f, indent=2)
         f.write("\n")
 
     # Copy icons to dist
@@ -721,6 +799,10 @@ def build_registry(dry_run: bool = False):
     print(
         f"  registry-for-jetbrains.json: {len(jetbrains_agents)} agents"
         f" (excluded: {', '.join(sorted(JETBRAINS_EXCLUDE_IDS))})"
+    )
+    print(
+        f"  registry-for-jetbrains-preview.json: {len(jetbrains_preview_agents)} agents"
+        f" ({preview_summary()})"
     )
 
 

--- a/.github/workflows/registry_utils.py
+++ b/.github/workflows/registry_utils.py
@@ -1,6 +1,7 @@
 """Shared utilities for ACP registry scripts."""
 
 import contextlib
+import copy
 import json
 import os
 import re
@@ -99,6 +100,12 @@ AGENT_ENV_RESERVED_NAMES_NORMALIZED = {name.upper() for name in AGENT_ENV_RESERV
 AGENT_ENV_RESERVED_PREFIXES_NORMALIZED = tuple(
     prefix.upper() for prefix in AGENT_ENV_RESERVED_PREFIXES
 )
+
+# Preview channel version scheme: X.Y.Z-preview.N
+PREVIEW_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)-preview\.(\d+)$")
+
+# Version part of a uvx package spec (`pkg==1.2.3`, `pkg@1.2.3-preview.4`, ...)
+UVX_VERSION_PATTERN = r"[\d.]+(?:-preview\.\d+)?"
 
 
 def should_skip_dir(name: str) -> bool:
@@ -243,6 +250,79 @@ def normalize_version(version: str) -> str:
     while len(parts) < 3:
         parts.append("0")
     return ".".join(parts[:3])
+
+
+def normalize_release_version(version: str | None) -> str | None:
+    """Normalize comparable release versions to a consistent dotted form."""
+    if not version:
+        return None
+    if re.fullmatch(r"\d+", version):
+        return f"{version}.0.0"
+    if re.fullmatch(r"\d+\.\d+", version):
+        return f"{version}.0"
+    return version
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+    """Return a sortable key for numeric dotted release versions."""
+    normalized = normalize_release_version(version)
+    if not normalized or not re.fullmatch(r"\d+(?:\.\d+)*", normalized):
+        raise ValueError(f"Unsupported version format: {version}")
+    return tuple(int(part) for part in normalized.split("."))
+
+
+def parse_preview_version(version: str) -> tuple[tuple[int, int, int], int] | None:
+    """Parse `X.Y.Z-preview.N` into ((X, Y, Z), N); return None for any other shape."""
+    match = PREVIEW_VERSION_RE.match(version or "")
+    if not match:
+        return None
+    major, minor, patch, counter = (int(part) for part in match.groups())
+    return (major, minor, patch), counter
+
+
+def is_preview_version(version: str) -> bool:
+    """Return whether a version string is an `X.Y.Z-preview.N` prerelease."""
+    return parse_preview_version(version) is not None
+
+
+def semver_sort_key(version: str) -> tuple:
+    """Return a total order over `X.Y.Z` and `X.Y.Z-preview.N` version strings.
+
+    A release ranks above its own prereleases (semver 11.3) and prerelease
+    counters compare numerically (semver 11.4.1).
+    """
+    parsed = parse_preview_version(version)
+    if parsed is None:
+        return (version_tuple(version), 1, 0)
+    release, counter = parsed
+    return (release, 0, counter)
+
+
+def strip_preview(agent: dict) -> dict:
+    """Return a deep copy of an agent entry with the `preview` block removed."""
+    entry = copy.deepcopy(agent)
+    entry.pop("preview", None)
+    return entry
+
+
+def resolve_preview_entry(agent: dict) -> dict:
+    """Return the preview-channel view of an agent entry; the highest channel wins.
+
+    Falls back to the stable entry when there is no `preview` block or when the
+    stable `version` is at or above `preview.version`. Otherwise `version` and
+    `distribution` are replaced wholesale by the preview values and the
+    `preview` key is dropped, so the result is an ordinary agent entry.
+    """
+    preview = agent.get("preview")
+    if not preview:
+        return strip_preview(agent)
+    if semver_sort_key(agent["version"]) >= semver_sort_key(preview["version"]):
+        return strip_preview(agent)
+    entry = copy.deepcopy(agent)
+    entry["version"] = preview["version"]
+    entry["distribution"] = copy.deepcopy(preview["distribution"])
+    entry.pop("preview")
+    return entry
 
 
 def load_quarantine(registry_dir: Path) -> dict[str, str]:

--- a/.github/workflows/scripts/run-workflows-tests.sh
+++ b/.github/workflows/scripts/run-workflows-tests.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 "$SCRIPT_DIR/run-registry-docker.sh" \
-  /bin/sh -lc 'cd /workspace/.github/workflows && uv run --no-project --with pytest pytest tests/ -v "$@"' \
+  /bin/sh -lc 'cd /workspace/.github/workflows && uv run --no-project --with pytest --with jsonschema pytest tests/ -v "$@"' \
   run-workflows-tests "$@"

--- a/.github/workflows/tests/test_build_registry.py
+++ b/.github/workflows/tests/test_build_registry.py
@@ -1,10 +1,27 @@
 """Tests for build_registry icon validation and dry-run."""
 
+import json
+import shutil
 import tempfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from build_registry import is_public_https_url, url_exists, validate_icon, validate_icon_monochrome
+import pytest
+
+from build_registry import (
+    HAS_JSONSCHEMA,
+    build_registry,
+    is_public_https_url,
+    url_exists,
+    validate_icon,
+    validate_icon_monochrome,
+    validate_preview,
+)
+from registry_utils import semver_sort_key
+
+requires_jsonschema = pytest.mark.skipif(
+    not HAS_JSONSCHEMA, reason="schema-only rule needs jsonschema installed"
+)
 
 
 def socket_result(ip: str):
@@ -297,3 +314,357 @@ class TestValidateIcon:
             )
             errors = validate_icon(p)
             assert any("HTML comments" in e for e in errors)
+
+
+# --- preview channel ---
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VALID_ICON = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">'
+    '<path fill="currentColor" d="M0 0z"/>'
+    "</svg>"
+)
+
+
+def npx_preview(agent_id: str, version: str) -> dict:
+    return {
+        "version": version,
+        "distribution": {"npx": {"package": f"@acp/{agent_id}@{version}"}},
+    }
+
+
+def agent_manifest(agent_id: str, version: str, preview: dict | None = None, **extra) -> dict:
+    manifest = {
+        "id": agent_id,
+        "name": agent_id,
+        "version": version,
+        "description": f"{agent_id} test agent",
+        "distribution": {"npx": {"package": f"@acp/{agent_id}@{version}"}},
+    }
+    manifest.update(extra)
+    if preview is not None:
+        manifest["preview"] = preview
+    return manifest
+
+
+def write_registry(root: Path, manifests: list[dict]) -> Path:
+    shutil.copy(REPO_ROOT / "agent.schema.json", root / "agent.schema.json")
+    for manifest in manifests:
+        entry_dir = root / manifest["id"]
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        (entry_dir / "agent.json").write_text(json.dumps(manifest, indent=2) + "\n")
+        (entry_dir / "icon.svg").write_text(VALID_ICON)
+    return root
+
+
+def read_registries(root: Path) -> dict[str, dict]:
+    return {
+        name: json.loads((root / "dist" / f"{name}.json").read_text())
+        for name in ("registry", "registry-for-jetbrains", "registry-for-jetbrains-preview")
+    }
+
+
+def by_id(registry: dict) -> dict[str, dict]:
+    return {agent["id"]: agent for agent in registry["agents"]}
+
+
+@pytest.fixture(autouse=True)
+def _skip_url_validation(monkeypatch):
+    monkeypatch.setattr("build_registry.SKIP_URL_VALIDATION", True)
+
+
+class TestValidatePreview:
+    def test_no_preview_block(self):
+        assert validate_preview(agent_manifest("agent-a", "1.8.0")) == []
+
+    def test_valid_preview_block(self):
+        agent = agent_manifest("agent-a", "1.8.0", npx_preview("agent-a", "1.9.0-preview.1"))
+
+        assert validate_preview(agent) == []
+
+    def test_plain_release_preview_version(self):
+        agent = agent_manifest("agent-a", "1.8.0", npx_preview("agent-a", "1.9.1"))
+
+        assert validate_preview(agent) == []
+
+    @pytest.mark.parametrize(
+        "version",
+        ["1.9-preview.1", "1.9.0-preview", "1.9.0-rc.1", "1.9.0+preview.1", "latest"],
+    )
+    def test_malformed_preview_version(self, version):
+        agent = agent_manifest("agent-a", "1.8.0", npx_preview("agent-a", version))
+
+        errors = validate_preview(agent)
+
+        assert any("preview.version" in e for e in errors)
+
+    def test_package_spec_disagreeing_with_preview_version(self):
+        agent = agent_manifest(
+            "agent-a",
+            "1.8.0",
+            {
+                "version": "1.9.0-preview.2",
+                "distribution": {"npx": {"package": "@acp/agent-a@1.9.0-preview.1"}},
+            },
+        )
+
+        errors = validate_preview(agent)
+
+        assert any("doesn't match" in e for e in errors)
+
+    def test_empty_preview_distribution(self):
+        agent = agent_manifest(
+            "agent-a", "1.8.0", {"version": "1.9.0-preview.1", "distribution": {}}
+        )
+
+        errors = validate_preview(agent)
+
+        assert any("preview.distribution" in e for e in errors)
+
+    def test_uvx_preview_spec_matching_preview_version(self):
+        agent = agent_manifest(
+            "agent-a",
+            "1.8.0",
+            {
+                "version": "1.9.0-preview.1",
+                "distribution": {"uvx": {"package": "acp-agent-a==1.9.0-preview.1"}},
+            },
+        )
+
+        assert validate_preview(agent) == []
+
+    def test_no_ordering_constraint_against_stable(self):
+        agent = agent_manifest("agent-a", "1.9.1", npx_preview("agent-a", "1.9.0-preview.1"))
+
+        assert validate_preview(agent) == []
+
+
+class TestPreviewRegistryOutputs:
+    def test_writes_three_registries(self, tmp_path):
+        write_registry(
+            tmp_path,
+            [
+                agent_manifest("agent-a", "1.8.0", npx_preview("agent-a", "1.9.0-preview.2")),
+                agent_manifest("agent-b", "2.0.0"),
+            ],
+        )
+
+        build_registry(registry_dir=tmp_path)
+
+        registries = read_registries(tmp_path)
+        assert set(registries) == {
+            "registry",
+            "registry-for-jetbrains",
+            "registry-for-jetbrains-preview",
+        }
+
+    def test_public_registries_hide_the_preview_channel(self, tmp_path):
+        write_registry(
+            tmp_path,
+            [agent_manifest("agent-a", "1.8.0", npx_preview("agent-a", "1.9.0-preview.2"))],
+        )
+
+        build_registry(registry_dir=tmp_path)
+        registries = read_registries(tmp_path)
+
+        for name in ("registry", "registry-for-jetbrains"):
+            entry = by_id(registries[name])["agent-a"]
+            assert "preview" not in entry
+            assert entry["version"] == "1.8.0"
+            assert entry["distribution"]["npx"]["package"] == "@acp/agent-a@1.8.0"
+
+    def test_preview_registry_substitutes_version_and_distribution(self, tmp_path):
+        write_registry(
+            tmp_path,
+            [
+                agent_manifest(
+                    "agent-a",
+                    "1.8.0",
+                    npx_preview("agent-a", "1.9.0-preview.2"),
+                    repository="https://github.com/acp/agent-a",
+                    authors=["ACP"],
+                    license="proprietary",
+                )
+            ],
+        )
+
+        build_registry(registry_dir=tmp_path)
+        registries = read_registries(tmp_path)
+
+        stable = by_id(registries["registry-for-jetbrains"])["agent-a"]
+        preview = by_id(registries["registry-for-jetbrains-preview"])["agent-a"]
+
+        assert "preview" not in preview
+        assert preview["version"] == "1.9.0-preview.2"
+        assert preview["distribution"]["npx"]["package"] == "@acp/agent-a@1.9.0-preview.2"
+        for field in ("id", "name", "description", "repository", "authors", "license", "icon"):
+            assert preview[field] == stable[field]
+
+    def test_agent_without_preview_block_uses_stable_entry(self, tmp_path):
+        write_registry(tmp_path, [agent_manifest("agent-b", "2.0.0")])
+
+        build_registry(registry_dir=tmp_path)
+        registries = read_registries(tmp_path)
+
+        assert (
+            by_id(registries["registry-for-jetbrains-preview"])["agent-b"]
+            == by_id(registries["registry-for-jetbrains"])["agent-b"]
+        )
+
+    def test_stable_ahead_of_preview_line_serves_stable(self, tmp_path):
+        write_registry(
+            tmp_path,
+            [agent_manifest("agent-a", "1.9.1", npx_preview("agent-a", "1.9.0-preview.1"))],
+        )
+
+        build_registry(registry_dir=tmp_path)
+        registries = read_registries(tmp_path)
+
+        entry = by_id(registries["registry-for-jetbrains-preview"])["agent-a"]
+        assert entry["version"] == "1.9.1"
+        assert entry["distribution"]["npx"]["package"] == "@acp/agent-a@1.9.1"
+        assert "preview" not in entry
+
+    def test_preview_version_never_below_stable(self, tmp_path):
+        write_registry(
+            tmp_path,
+            [
+                agent_manifest("agent-a", "1.8.0", npx_preview("agent-a", "1.9.0-preview.2")),
+                agent_manifest("agent-b", "2.0.0"),
+                agent_manifest("agent-c", "1.9.1", npx_preview("agent-c", "1.9.0-preview.1")),
+                agent_manifest("agent-d", "1.9.0", npx_preview("agent-d", "1.9.1")),
+            ],
+        )
+
+        build_registry(registry_dir=tmp_path)
+        registries = read_registries(tmp_path)
+
+        stable = by_id(registries["registry-for-jetbrains"])
+        preview = by_id(registries["registry-for-jetbrains-preview"])
+        assert set(stable) == set(preview)
+        for agent_id, entry in preview.items():
+            assert semver_sort_key(entry["version"]) >= semver_sort_key(stable[agent_id]["version"])
+
+    def test_jetbrains_patches_apply_to_the_preview_registry(self, tmp_path):
+        write_registry(
+            tmp_path,
+            [
+                agent_manifest(
+                    "claude-acp", "0.73.0", npx_preview("claude-acp", "0.74.0-preview.1")
+                ),
+                agent_manifest("github-copilot-cli", "1.0.0"),
+                agent_manifest("github-copilot", "1.0.0"),
+            ],
+        )
+
+        build_registry(registry_dir=tmp_path)
+        registries = read_registries(tmp_path)
+
+        preview_agents = by_id(registries["registry-for-jetbrains-preview"])
+        claude = preview_agents["claude-acp"]
+        assert claude["bundled"] is True
+        assert "--hide-claude-auth" in claude["distribution"]["npx"]["args"]
+        assert claude["version"] == "0.74.0-preview.1"
+        assert "github-copilot-cli" not in preview_agents
+        assert "github-copilot" in preview_agents
+        assert "github-copilot" not in by_id(registries["registry"])
+
+    def test_preview_may_declare_a_distribution_type_the_base_entry_lacks(self, tmp_path):
+        write_registry(
+            tmp_path,
+            [
+                agent_manifest(
+                    "agent-a",
+                    "1.8.0",
+                    {
+                        "version": "1.9.0-preview.1",
+                        "distribution": {"uvx": {"package": "acp-agent-a==1.9.0-preview.1"}},
+                    },
+                )
+            ],
+        )
+
+        build_registry(registry_dir=tmp_path)
+        registries = read_registries(tmp_path)
+
+        entry = by_id(registries["registry-for-jetbrains-preview"])["agent-a"]
+        assert entry["distribution"] == {"uvx": {"package": "acp-agent-a==1.9.0-preview.1"}}
+
+    def test_no_network_probe_for_preview_artifacts(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("build_registry.SKIP_URL_VALIDATION", False)
+        probed: list[str] = []
+
+        def record(url, *args, **kwargs):
+            probed.append(url)
+            return True
+
+        monkeypatch.setattr("build_registry.url_exists", record)
+        write_registry(
+            tmp_path,
+            [agent_manifest("agent-a", "1.8.0", npx_preview("agent-a", "1.9.0-preview.2"))],
+        )
+
+        build_registry(registry_dir=tmp_path)
+
+        assert probed == ["https://registry.npmjs.org/@acp/agent-a"]
+
+
+class TestPreviewValidationFailures:
+    def _build_fails(self, tmp_path, manifest) -> None:
+        write_registry(tmp_path, [manifest])
+        with pytest.raises(SystemExit) as excinfo:
+            build_registry(registry_dir=tmp_path)
+        assert excinfo.value.code == 1
+
+    @requires_jsonschema
+    def test_extra_key_in_preview_block(self, tmp_path):
+        preview = npx_preview("agent-a", "1.9.0-preview.1")
+        preview["name"] = "Agent A Preview"
+
+        self._build_fails(tmp_path, agent_manifest("agent-a", "1.8.0", preview))
+
+    def test_preview_without_distribution(self, tmp_path):
+        self._build_fails(
+            tmp_path, agent_manifest("agent-a", "1.8.0", {"version": "1.9.0-preview.1"})
+        )
+
+    def test_empty_preview_distribution(self, tmp_path):
+        self._build_fails(
+            tmp_path,
+            agent_manifest("agent-a", "1.8.0", {"version": "1.9.0-preview.1", "distribution": {}}),
+        )
+
+    @requires_jsonschema
+    def test_binary_preview_distribution(self, tmp_path):
+        self._build_fails(
+            tmp_path,
+            agent_manifest(
+                "agent-a",
+                "1.8.0",
+                {
+                    "version": "1.9.0-preview.1",
+                    "distribution": {
+                        "darwin-aarch64": {
+                            "archive": "https://example.com/a-1.9.0-preview.1.tar.gz",
+                            "cmd": "agent-a",
+                        }
+                    },
+                },
+            ),
+        )
+
+    def test_preview_package_spec_version_mismatch(self, tmp_path):
+        self._build_fails(
+            tmp_path,
+            agent_manifest(
+                "agent-a",
+                "1.8.0",
+                {
+                    "version": "1.9.0-preview.2",
+                    "distribution": {"npx": {"package": "@acp/agent-a@1.9.0-preview.1"}},
+                },
+            ),
+        )
+
+    def test_prerelease_in_root_version(self, tmp_path):
+        self._build_fails(tmp_path, agent_manifest("agent-a", "1.9.0-preview.1"))

--- a/.github/workflows/tests/test_build_registry.py
+++ b/.github/workflows/tests/test_build_registry.py
@@ -339,6 +339,7 @@ def agent_manifest(agent_id: str, version: str, preview: dict | None = None, **e
         "name": agent_id,
         "version": version,
         "description": f"{agent_id} test agent",
+        "license_url": f"https://example.com/{agent_id}/license",
         "distribution": {"npx": {"package": f"@acp/{agent_id}@{version}"}},
     }
     manifest.update(extra)

--- a/.github/workflows/tests/test_registry_utils.py
+++ b/.github/workflows/tests/test_registry_utils.py
@@ -14,12 +14,18 @@ from registry_utils import (
     extract_npm_package_name,
     extract_npm_package_version,
     extract_pypi_package_name,
+    is_preview_version,
     load_quarantine,
     normalize_version,
+    parse_preview_version,
+    resolve_preview_entry,
     sanitize_agent_env,
+    semver_sort_key,
     should_skip_dir,
+    strip_preview,
     subprocess_group_kwargs,
     terminate_process_group,
+    version_tuple,
 )
 
 
@@ -80,6 +86,167 @@ class TestNormalizeVersion:
 
     def test_four_parts_truncated(self):
         assert normalize_version("1.2.3.4") == "1.2.3"
+
+
+class TestVersionTuple:
+    def test_pads_short_versions(self):
+        assert version_tuple("1") == (1, 0, 0)
+        assert version_tuple("1.2") == (1, 2, 0)
+
+    def test_keeps_extra_components(self):
+        assert version_tuple("1.2.3.4") == (1, 2, 3, 4)
+
+    def test_rejects_prerelease(self):
+        with pytest.raises(ValueError):
+            version_tuple("1.9.0-preview.1")
+
+
+class TestParsePreviewVersion:
+    def test_parses_preview(self):
+        assert parse_preview_version("1.9.0-preview.3") == ((1, 9, 0), 3)
+
+    def test_plain_release_is_not_preview(self):
+        assert parse_preview_version("1.9.0") is None
+        assert not is_preview_version("1.9.0")
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "1.0-preview-1",
+            "1.0-preview.1",
+            "1.9.0-preview",
+            "1.9.0-preview.",
+            "1.9.0-rc.1",
+            "1.9.0-next.1",
+            "1.9.0+preview.1",
+            "v1.9.0-preview.1",
+            "",
+        ],
+    )
+    def test_rejects_unsupported_shapes(self, version):
+        assert parse_preview_version(version) is None
+        assert not is_preview_version(version)
+
+
+class TestSemverSortKey:
+    def test_total_ordering(self):
+        ordered = [
+            "1.9.0-preview.2",
+            "1.9.0-preview.10",
+            "1.9.0",
+            "1.9.1-preview.1",
+            "1.9.1",
+        ]
+        assert sorted(ordered, key=semver_sort_key) == ordered
+
+    def test_numeric_counter_comparison(self):
+        assert semver_sort_key("1.9.0-preview.10") > semver_sort_key("1.9.0-preview.2")
+
+    def test_prerelease_ranks_below_its_release(self):
+        assert semver_sort_key("1.9.0-preview.99") < semver_sort_key("1.9.0")
+
+    def test_release_ranks_below_next_prerelease(self):
+        assert semver_sort_key("1.9.0") < semver_sort_key("1.9.1-preview.1")
+
+
+def _agent(version: str, preview: dict | None = None) -> dict:
+    agent = {
+        "id": "codex-acp",
+        "name": "Codex",
+        "version": version,
+        "description": "ACP adapter",
+        "repository": "https://github.com/agentclientprotocol/codex-acp",
+        "authors": ["OpenAI"],
+        "license": "proprietary",
+        "distribution": {
+            "npx": {
+                "package": f"@agentclientprotocol/codex-acp@{version}",
+                "args": ["--stable-flag"],
+            }
+        },
+    }
+    if preview is not None:
+        agent["preview"] = preview
+    return agent
+
+
+def _preview(version: str) -> dict:
+    return {
+        "version": version,
+        "distribution": {"npx": {"package": f"@agentclientprotocol/codex-acp@{version}"}},
+    }
+
+
+class TestStripPreview:
+    def test_removes_preview_block(self):
+        agent = _agent("1.8.0", _preview("1.9.0-preview.1"))
+
+        stripped = strip_preview(agent)
+
+        assert "preview" not in stripped
+        assert stripped["version"] == "1.8.0"
+        assert "preview" in agent  # input untouched
+
+    def test_no_preview_block_is_a_copy(self):
+        agent = _agent("1.8.0")
+
+        stripped = strip_preview(agent)
+
+        assert stripped == agent
+        assert stripped["distribution"] is not agent["distribution"]
+
+
+class TestResolvePreviewEntry:
+    def test_no_preview_block_returns_base_entry(self):
+        agent = _agent("1.8.0")
+
+        assert resolve_preview_entry(agent) == agent
+
+    def test_preview_ahead_substitutes_version_and_distribution(self):
+        agent = _agent("1.8.0", _preview("1.9.0-preview.1"))
+
+        entry = resolve_preview_entry(agent)
+
+        assert "preview" not in entry
+        assert entry["version"] == "1.9.0-preview.1"
+        assert entry["distribution"] == {
+            "npx": {"package": "@agentclientprotocol/codex-acp@1.9.0-preview.1"}
+        }
+        for field in ("id", "name", "description", "repository", "authors", "license"):
+            assert entry[field] == agent[field]
+        assert list(entry.keys()) == [k for k in agent if k != "preview"]
+
+    def test_stable_ahead_falls_back_to_base_entry(self):
+        agent = _agent("1.9.1", _preview("1.9.0-preview.1"))
+
+        entry = resolve_preview_entry(agent)
+
+        assert entry == strip_preview(agent)
+        assert entry["version"] == "1.9.1"
+
+    def test_equal_versions_fall_back_to_base_entry(self):
+        agent = _agent("1.9.1", _preview("1.9.1"))
+
+        entry = resolve_preview_entry(agent)
+
+        assert entry == strip_preview(agent)
+
+    def test_plain_release_preview_ahead_is_substituted(self):
+        agent = _agent("1.9.0", _preview("1.9.1"))
+
+        entry = resolve_preview_entry(agent)
+
+        assert entry["version"] == "1.9.1"
+        assert entry["distribution"]["npx"]["package"].endswith("@1.9.1")
+        assert "preview" not in entry
+
+    def test_result_is_detached_from_input(self):
+        agent = _agent("1.8.0", _preview("1.9.0-preview.1"))
+
+        entry = resolve_preview_entry(agent)
+        entry["distribution"]["npx"]["package"] = "mutated"
+
+        assert agent["preview"]["distribution"]["npx"]["package"] != "mutated"
 
 
 class TestLoadQuarantine:

--- a/.github/workflows/tests/test_update_versions.py
+++ b/.github/workflows/tests/test_update_versions.py
@@ -10,7 +10,10 @@ import pytest
 from update_versions import (
     VersionUpdate,
     apply_update,
+    check_agent_preview_version,
     check_agent_version,
+    get_highest_preview_version,
+    get_npm_versions,
     is_prerelease,
     make_request,
 )
@@ -306,6 +309,7 @@ class TestApplyUpdateSha256Refresh:
             distribution_type="binary",
             source_url="https://github.com/owner/repo",
             repository="https://github.com/owner/repo",
+            channel="stable",
         )
 
     @patch("update_versions.get_github_release_digests")
@@ -358,3 +362,235 @@ class TestApplyUpdateSha256Refresh:
 
         mock_digests.assert_not_called()
         assert "no release digest" not in capsys.readouterr().err
+
+
+# --- preview channel ---
+
+
+def preview_agent_data(version: str, preview_version: str | None) -> dict:
+    agent_data: dict = {
+        "id": "codex-acp",
+        "name": "Codex",
+        "version": version,
+        "description": "",
+        "repository": "https://github.com/agentclientprotocol/codex-acp",
+        "distribution": {"npx": {"package": f"@acp/codex-acp@{version}"}},
+    }
+    if preview_version is not None:
+        agent_data["preview"] = {
+            "version": preview_version,
+            "distribution": {"npx": {"package": f"@acp/codex-acp@{preview_version}"}},
+        }
+    return agent_data
+
+
+class TestGetHighestPreviewVersion:
+    def test_picks_highest_preview_by_semver(self):
+        versions = {"1.8.0", "1.9.0-preview.2", "1.9.0-preview.10", "1.10.0"}
+
+        assert get_highest_preview_version(versions) == "1.9.0-preview.10"
+
+    def test_none_when_no_previews_published(self):
+        assert get_highest_preview_version({"1.8.0", "1.9.0"}) is None
+
+    def test_ignores_other_prerelease_shapes(self):
+        assert get_highest_preview_version({"1.9.0-rc.1", "0.1.17rc0"}) is None
+
+
+class TestCheckAgentPreviewVersion:
+    @patch("update_versions.get_npm_versions")
+    def test_bumps_preview_and_leaves_stable_alone(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.8.0", "1.9.0-preview.1", "1.9.0-preview.2"}
+        agent_data = preview_agent_data("1.8.0", "1.9.0-preview.1")
+
+        stable_update, stable_error = check_agent_version(Path("codex-acp/agent.json"), agent_data)
+        preview_update, preview_error = check_agent_preview_version(
+            Path("codex-acp/agent.json"), agent_data
+        )
+
+        assert (stable_update, stable_error) == (None, None)
+        assert preview_error is None
+        assert preview_update is not None
+        assert preview_update.channel == "preview"
+        assert preview_update.current_version == "1.9.0-preview.1"
+        assert preview_update.latest_version == "1.9.0-preview.2"
+
+    @patch("update_versions.get_npm_versions")
+    def test_stable_release_overtakes_the_preview_line(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.9.1", "1.9.0-preview.1"}
+        agent_data = preview_agent_data("1.9.1", "1.9.0-preview.1")
+
+        update, error = check_agent_preview_version(Path("codex-acp/agent.json"), agent_data)
+
+        assert error is None
+        assert update is not None
+        assert update.latest_version == "1.9.1"
+
+    @patch("update_versions.get_npm_versions")
+    def test_next_preview_line_outranks_stable(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.9.1", "1.10.0-preview.1"}
+        agent_data = preview_agent_data("1.9.1", "1.9.1")
+
+        update, error = check_agent_preview_version(Path("codex-acp/agent.json"), agent_data)
+
+        assert error is None
+        assert update is not None
+        assert update.latest_version == "1.10.0-preview.1"
+
+    @patch("update_versions.get_npm_versions")
+    def test_no_update_when_already_at_the_candidate(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.8.0", "1.9.0-preview.2"}
+        agent_data = preview_agent_data("1.8.0", "1.9.0-preview.2")
+
+        assert check_agent_preview_version(Path("codex-acp/agent.json"), agent_data) == (None, None)
+
+    @patch("update_versions.get_npm_versions")
+    def test_no_preview_block_yields_no_preview_update(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.8.0", "1.9.0-preview.2"}
+        agent_data = preview_agent_data("1.8.0", None)
+
+        assert check_agent_preview_version(Path("codex-acp/agent.json"), agent_data) == (None, None)
+
+    @patch("update_versions.get_npm_versions")
+    def test_no_ordering_error_when_preview_is_behind_stable(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.9.0-preview.1"}
+        agent_data = preview_agent_data("1.9.1", "1.9.0-preview.1")
+
+        update, error = check_agent_preview_version(Path("codex-acp/agent.json"), agent_data)
+
+        assert error is None
+        assert update is None
+
+    @patch("update_versions.get_github_release_versions")
+    @patch("update_versions.get_npm_versions")
+    def test_only_preview_declared_distributions_participate(
+        self, mock_npm_versions, mock_gh_release_versions
+    ):
+        mock_npm_versions.return_value = {"1.8.0", "1.9.0-preview.1"}
+        agent_data = preview_agent_data("1.8.0", "1.8.0")
+        agent_data["distribution"]["binary"] = {
+            "darwin-aarch64": {
+                "archive": "https://github.com/owner/repo/releases/download/v1.8.0/a.tar.gz",
+                "cmd": "./a",
+            }
+        }
+
+        update, error = check_agent_preview_version(Path("codex-acp/agent.json"), agent_data)
+
+        assert error is None
+        assert update is not None
+        assert update.latest_version == "1.9.0-preview.1"
+        assert update.distribution_type == "npx"
+        mock_gh_release_versions.assert_not_called()
+
+    @patch("update_versions.get_npm_versions")
+    def test_one_fetch_is_shared_across_channels(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.8.0", "1.9.0-preview.1"}
+        agent_data = preview_agent_data("1.8.0", "1.8.0")
+        cache: dict = {}
+
+        check_agent_version(Path("codex-acp/agent.json"), agent_data, cache)
+        check_agent_preview_version(Path("codex-acp/agent.json"), agent_data, cache)
+
+        mock_npm_versions.assert_called_once_with("@acp/codex-acp")
+
+
+class TestApplyUpdateChannels:
+    def _write(self, tmp_path: Path) -> Path:
+        agent_path = tmp_path / "agent.json"
+        agent_path.write_text(json.dumps(preview_agent_data("1.8.0", "1.9.0-preview.1"), indent=2))
+        return agent_path
+
+    def _update(self, agent_path: Path, channel: str, latest: str) -> VersionUpdate:
+        return VersionUpdate(
+            agent_id="codex-acp",
+            agent_path=agent_path,
+            current_version="1.9.0-preview.1" if channel == "preview" else "1.8.0",
+            latest_version=latest,
+            distribution_type="npx",
+            source_url="https://registry.npmjs.org/@acp/codex-acp",
+            repository="https://github.com/agentclientprotocol/codex-acp",
+            channel=channel,
+        )
+
+    def test_preview_update_touches_only_the_preview_block(self, tmp_path: Path):
+        agent_path = self._write(tmp_path)
+
+        assert apply_update(self._update(agent_path, "preview", "1.9.0-preview.2")) is True
+
+        updated = json.loads(agent_path.read_text())
+        assert updated["version"] == "1.8.0"
+        assert updated["distribution"]["npx"]["package"] == "@acp/codex-acp@1.8.0"
+        assert updated["preview"]["version"] == "1.9.0-preview.2"
+        preview_dist = updated["preview"]["distribution"]
+        assert preview_dist["npx"]["package"] == "@acp/codex-acp@1.9.0-preview.2"
+
+    def test_preview_update_can_pin_a_plain_release(self, tmp_path: Path):
+        agent_path = self._write(tmp_path)
+
+        assert apply_update(self._update(agent_path, "preview", "1.9.1")) is True
+
+        updated = json.loads(agent_path.read_text())
+        assert updated["preview"]["version"] == "1.9.1"
+        assert updated["preview"]["distribution"]["npx"]["package"] == "@acp/codex-acp@1.9.1"
+
+    def test_stable_update_leaves_the_preview_block_untouched(self, tmp_path: Path):
+        agent_path = self._write(tmp_path)
+        before = json.loads(agent_path.read_text())["preview"]
+
+        assert apply_update(self._update(agent_path, "stable", "1.8.1")) is True
+
+        updated = json.loads(agent_path.read_text())
+        assert updated["version"] == "1.8.1"
+        assert updated["distribution"]["npx"]["package"] == "@acp/codex-acp@1.8.1"
+        assert updated["preview"] == before
+
+    def test_preview_update_fails_without_a_preview_block(self, tmp_path: Path, capsys):
+        agent_path = tmp_path / "agent.json"
+        agent_path.write_text(json.dumps(preview_agent_data("1.8.0", None), indent=2))
+
+        assert apply_update(self._update(agent_path, "preview", "1.9.0-preview.2")) is False
+        assert "no 'preview' block" in capsys.readouterr().err
+
+    def test_uvx_preview_spec_is_rewritten(self, tmp_path: Path):
+        agent_data = preview_agent_data("1.8.0", "1.9.0-preview.1")
+        agent_data["preview"]["distribution"] = {"uvx": {"package": "codex-acp==1.9.0-preview.1"}}
+        agent_path = tmp_path / "agent.json"
+        agent_path.write_text(json.dumps(agent_data, indent=2))
+
+        assert apply_update(self._update(agent_path, "preview", "1.9.0-preview.2")) is True
+
+        updated = json.loads(agent_path.read_text())
+        assert updated["preview"]["distribution"]["uvx"]["package"] == "codex-acp==1.9.0-preview.2"
+
+
+class TestNpmDistTagsFallback:
+    """A preview published without `--tag preview` must not surface as stable."""
+
+    @patch("update_versions.make_request")
+    def test_prerelease_dist_tag_is_not_returned(self, mock_request):
+        mock_request.return_value = {"dist-tags": {"latest": "1.9.0-preview.1"}}
+
+        assert get_npm_versions("@acp/codex-acp") is None
+
+    @patch("update_versions.make_request")
+    def test_stable_dist_tag_is_returned(self, mock_request):
+        mock_request.return_value = {"dist-tags": {"latest": "1.9.0"}}
+
+        assert get_npm_versions("@acp/codex-acp") == {"1.9.0"}
+
+    @patch("update_versions.make_request")
+    def test_versions_map_includes_previews(self, mock_request):
+        mock_request.return_value = {
+            "versions": {"1.8.0": {}, "1.9.0-preview.1": {}},
+            "dist-tags": {"latest": "1.8.0"},
+        }
+
+        assert get_npm_versions("@acp/codex-acp") == {"1.8.0", "1.9.0-preview.1"}
+
+    @patch("update_versions.get_npm_versions")
+    def test_stable_channel_ignores_published_previews(self, mock_npm_versions):
+        mock_npm_versions.return_value = {"1.8.0", "1.9.0-preview.1"}
+        agent_data = preview_agent_data("1.8.0", "1.9.0-preview.1")
+
+        assert check_agent_version(Path("codex-acp/agent.json"), agent_data) == (None, None)

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -180,14 +180,20 @@ jobs:
 
           data = json.loads(os.environ["UPDATES_JSON"])
           updates = data.get("updates", [])
+          # path -> {channel -> version}: both channels of one agent live in the
+          # same file, so a path-only key would let one channel mask the other.
           expected_versions = {}
           for update in updates:
               agent_id = update.get("agent_id", "")
+              channel = update.get("channel", "stable")
               latest_version = update.get("latest_version", "")
               if not re.fullmatch(r"[a-z][a-z0-9-]*", agent_id):
                   print(f"Invalid agent id in update JSON: {agent_id!r}", file=sys.stderr)
                   sys.exit(1)
-              expected_versions[f"{agent_id}/agent.json"] = latest_version
+              if channel not in ("stable", "preview"):
+                  print(f"Invalid channel in update JSON: {channel!r}", file=sys.stderr)
+                  sys.exit(1)
+              expected_versions.setdefault(f"{agent_id}/agent.json", {})[channel] = latest_version
 
           if not expected_versions:
               print("No expected update files found", file=sys.stderr)
@@ -225,16 +231,21 @@ jobs:
           base_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
           (artifact_dir / "base-sha.txt").write_text(base_sha + "\n")
 
-          for rel_path, expected_version in sorted(expected_versions.items()):
+          for rel_path, channel_versions in sorted(expected_versions.items()):
               source = Path(rel_path)
               agent = json.loads(source.read_text())
-              actual_version = agent.get("version")
-              if actual_version != expected_version:
-                  print(
-                      f"{rel_path} has version {actual_version!r}, expected {expected_version!r}",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
+              for channel, expected_version in sorted(channel_versions.items()):
+                  if channel == "preview":
+                      actual_version = (agent.get("preview") or {}).get("version")
+                  else:
+                      actual_version = agent.get("version")
+                  if actual_version != expected_version:
+                      print(
+                          f"{rel_path} has {channel} version {actual_version!r}, "
+                          f"expected {expected_version!r}",
+                          file=sys.stderr,
+                      )
+                      sys.exit(1)
               destination = artifact_dir / rel_path
               destination.parent.mkdir(parents=True, exist_ok=True)
               shutil.copy2(source, destination)
@@ -334,15 +345,22 @@ jobs:
         env:
           UPDATES_JSON: ${{ needs.check-versions.outputs.updates_json }}
         run: |
+          # The preview channel is explicitly unverified: preview distributions
+          # are never launched, so only stable bumps are auth-checked here.
           UPDATED_AGENTS=$(echo "$UPDATES_JSON" | python3 -c "
           import sys, json
           data = json.load(sys.stdin)
-          ids = [u['agent_id'] for u in data.get('updates', [])]
-          if not ids:
-              print('ERROR: No agent IDs found in updates JSON', file=sys.stderr)
-              sys.exit(1)
+          ids = sorted({
+              u['agent_id']
+              for u in data.get('updates', [])
+              if u.get('channel', 'stable') == 'stable'
+          })
           print(','.join(ids))
           ")
+          if [ -z "$UPDATED_AGENTS" ]; then
+            echo "No stable agent updates in this run; skipping auth verification"
+            exit 0
+          fi
           echo "Verifying updated agents: $UPDATED_AGENTS"
           python3 .github/workflows/verify_agents.py --auth-check --agent "$UPDATED_AGENTS"
 
@@ -432,9 +450,11 @@ jobs:
           updates = data.get('updates', [])
           if len(updates) == 1:
               u = updates[0]
-              print(f\"Update {u['agent_id']} to {u['latest_version']}\")
+              channel = u.get('channel', 'stable')
+              suffix = '' if channel == 'stable' else ' (' + channel + ')'
+              print('Update ' + u['agent_id'] + suffix + ' to ' + u['latest_version'])
           else:
-              print(f\"Update {len(updates)} agents to latest versions\")
+              print('Update ' + str(len(updates)) + ' agents to latest versions')
           ")
 
           # Generate details
@@ -442,7 +462,9 @@ jobs:
           import sys, json
           data = json.load(sys.stdin)
           for u in data.get('updates', []):
-              print(f\"- {u['agent_id']}: {u['current_version']} -> {u['latest_version']}\")
+              channel = u.get('channel', 'stable')
+              suffix = '' if channel == 'stable' else ' (' + channel + ')'
+              print('- ' + u['agent_id'] + suffix + ': ' + u['current_version'] + ' -> ' + u['latest_version'])
           ")
 
           echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update_versions.py
+++ b/.github/workflows/update_versions.py
@@ -12,6 +12,9 @@ Usage:
     # Check specific agents
     python .github/workflows/update_versions.py --agents gemini,goose
 
+    # Check one release channel only ('stable' or 'preview')
+    python .github/workflows/update_versions.py --channels preview
+
 Environment variables:
     GITHUB_TOKEN: GitHub token for API requests (increases rate limit)
 """
@@ -27,10 +30,15 @@ from pathlib import Path
 from typing import NamedTuple
 
 from registry_utils import (
+    UVX_VERSION_PATTERN,
     extract_npm_package_name,
     extract_pypi_package_name,
+    is_preview_version,
     load_quarantine,
+    normalize_release_version,
+    semver_sort_key,
     should_skip_dir,
+    version_tuple,
 )
 
 
@@ -44,6 +52,7 @@ class VersionUpdate(NamedTuple):
     distribution_type: str  # 'npx', 'uvx', 'binary', or combined like 'binary+npx'
     source_url: str  # URL where version was fetched from
     repository: str  # Agent's `repository` field (empty when unset)
+    channel: str = "stable"  # 'stable' or 'preview'
 
 
 class UpdateError(NamedTuple):
@@ -57,6 +66,8 @@ class UpdateError(NamedTuple):
 AGENT_DIRS = [
     ".",  # Root directory (active agents)
 ]
+
+CHANNELS = ("stable", "preview")
 
 
 def get_github_token() -> str | None:
@@ -99,41 +110,45 @@ def is_prerelease(version: str) -> bool:
     return not bool(re.fullmatch(r"\d+(?:\.\d+)*", normalized))
 
 
-def normalize_release_version(version: str | None) -> str | None:
-    """Normalize comparable release versions to a consistent dotted form."""
-    if not version:
-        return None
-    if re.fullmatch(r"\d+", version):
-        return f"{version}.0.0"
-    if re.fullmatch(r"\d+\.\d+", version):
-        return f"{version}.0"
-    return version
-
-
 def version_sort_key(version: str) -> tuple[int, ...]:
     """Return a sortable key for numeric dotted release versions."""
-    normalized = normalize_release_version(version)
-    if not normalized or not re.fullmatch(r"\d+(?:\.\d+)*", normalized):
-        raise ValueError(f"Unsupported version format: {version}")
-    return tuple(int(part) for part in normalized.split("."))
+    return version_tuple(version)
 
 
-def get_highest_stable_version(versions: set[str]) -> str | None:
-    """Return the highest non-prerelease version from a set."""
-    stable_versions = {
+def get_stable_versions(versions: set[str]) -> set[str]:
+    """Return the normalized non-prerelease subset of a published version set."""
+    return {
         normalized
         for version in versions
         if not is_prerelease(version)
         for normalized in [normalize_release_version(version)]
         if normalized is not None
     }
+
+
+def get_highest_stable_version(versions: set[str]) -> str | None:
+    """Return the highest non-prerelease version from a set."""
+    stable_versions = get_stable_versions(versions)
     if not stable_versions:
         return None
     return max(stable_versions, key=version_sort_key)
 
 
+def get_highest_preview_version(versions: set[str]) -> str | None:
+    """Return the highest `X.Y.Z-preview.N` version from a set."""
+    preview_versions = [version for version in versions if is_preview_version(version)]
+    if not preview_versions:
+        return None
+    return max(preview_versions, key=semver_sort_key)
+
+
 def get_npm_versions(package_name: str) -> set[str] | None:
-    """Get all stable published versions of an npm package."""
+    """Get all published versions of an npm package, prereleases included.
+
+    Callers partition the result per channel; the `dist-tags.latest` fallback
+    stays stable-only so a preview published without `--tag preview` can never
+    surface as a stable release.
+    """
     # Handle scoped packages: @scope/name -> %40scope%2Fname
     encoded_name = package_name.replace("@", "%40").replace("/", "%2F")
     url = f"https://registry.npmjs.org/{encoded_name}"
@@ -144,15 +159,14 @@ def get_npm_versions(package_name: str) -> set[str] | None:
     if isinstance(data, dict):
         versions = data.get("versions", {})
         if isinstance(versions, dict):
-            stable_versions = {
+            published_versions = {
                 normalized
                 for version in versions
-                if not is_prerelease(version)
                 for normalized in [normalize_release_version(version)]
                 if normalized is not None
             }
-            if stable_versions:
-                return stable_versions
+            if published_versions:
+                return published_versions
 
         dist_tags = data.get("dist-tags", {})
         if isinstance(dist_tags, dict):
@@ -163,23 +177,23 @@ def get_npm_versions(package_name: str) -> set[str] | None:
 
 
 def get_pypi_versions(package_name: str) -> set[str] | None:
-    """Get all stable published versions of a PyPI package."""
+    """Get all published versions of a PyPI package, prereleases included."""
     url = f"https://pypi.org/pypi/{package_name}/json"
     data = make_request(url)
     if isinstance(data, dict):
         releases = data.get("releases", {})
         if isinstance(releases, dict):
-            stable_versions = set()
+            published_versions = set()
             for version, files in releases.items():
-                if not files or is_prerelease(version):
+                if not files:
                     continue
                 if all(isinstance(file, dict) and file.get("yanked", False) for file in files):
                     continue
                 normalized = normalize_release_version(version)
                 if normalized:
-                    stable_versions.add(normalized)
-            if stable_versions:
-                return stable_versions
+                    published_versions.add(normalized)
+            if published_versions:
+                return published_versions
 
         info = data.get("info", {})
         if isinstance(info, dict):
@@ -321,10 +335,68 @@ def find_all_agents(registry_dir: Path) -> list[tuple[Path, dict]]:
     return agents
 
 
+def fetch_distribution_versions(
+    agent_id: str,
+    distribution: dict,
+    repository: str,
+    cache: dict[str, set[str] | None] | None = None,
+) -> tuple[dict[str, tuple[set[str], str]], UpdateError | None]:
+    """Fetch the published version list once per declared distribution source.
+
+    Returns a `{distribution_type: (published_versions, source_url)}` mapping.
+    Both channels partition that result in memory, and `cache` (keyed by source
+    URL) lets a single agent check reuse one fetch across channels, so adding
+    the preview channel costs no extra HTTP traffic.
+    """
+    if cache is None:
+        cache = {}
+    source_versions: dict[str, tuple[set[str], str]] = {}
+
+    def fetch(source_url: str, fetcher) -> set[str] | None:
+        if source_url not in cache:
+            cache[source_url] = fetcher()
+        return cache[source_url]
+
+    if "npx" in distribution:
+        package_spec = distribution["npx"].get("package", "")
+        package_name = extract_npm_package_name(package_spec)
+        if not package_name:
+            return {}, UpdateError(agent_id, "Could not extract npm package name")
+        source_url = f"https://registry.npmjs.org/{package_name}"
+        versions = fetch(source_url, lambda: get_npm_versions(package_name))
+        if not versions:
+            return {}, UpdateError(agent_id, f"Could not fetch npm versions for {package_name}")
+        source_versions["npx"] = (versions, source_url)
+
+    if "uvx" in distribution:
+        package_spec = distribution["uvx"].get("package", "")
+        package_name = extract_pypi_package_name(package_spec)
+        if not package_name:
+            return {}, UpdateError(agent_id, "Could not extract PyPI package name")
+        source_url = f"https://pypi.org/pypi/{package_name}/json"
+        versions = fetch(source_url, lambda: get_pypi_versions(package_name))
+        if not versions:
+            return {}, UpdateError(agent_id, f"Could not fetch PyPI versions for {package_name}")
+        source_versions["uvx"] = (versions, source_url)
+
+    if "binary" in distribution and _is_github_repo(repository):
+        versions = fetch(repository, lambda: get_github_release_versions(repository))
+        if not versions:
+            return {}, UpdateError(
+                agent_id,
+                f"Could not fetch GitHub releases for {repository}",
+            )
+        source_versions["binary"] = (versions, repository)
+
+    return source_versions, None
+
+
 def check_agent_version(
-    agent_path: Path, agent_data: dict
+    agent_path: Path,
+    agent_data: dict,
+    cache: dict[str, set[str] | None] | None = None,
 ) -> tuple[VersionUpdate | None, UpdateError | None]:
-    """Check if an agent has a newer version available.
+    """Check if an agent has a newer stable version available.
 
     Checks ALL distribution sources and fails if they report different versions.
     """
@@ -333,43 +405,24 @@ def check_agent_version(
     distribution = agent_data.get("distribution", {})
     repository = agent_data.get("repository", "")
 
-    # Collect stable published versions from all distribution sources
     current_version = normalize_release_version(current_version) or current_version
-    source_versions: dict[str, tuple[set[str], str]] = {}  # type -> (versions, source_url)
 
-    if "npx" in distribution:
-        package_spec = distribution["npx"].get("package", "")
-        package_name = extract_npm_package_name(package_spec)
-        if not package_name:
-            return None, UpdateError(agent_id, "Could not extract npm package name")
-        versions = get_npm_versions(package_name)
-        if not versions:
-            return None, UpdateError(agent_id, f"Could not fetch npm versions for {package_name}")
-        source_versions["npx"] = (versions, f"https://registry.npmjs.org/{package_name}")
+    published_versions, error = fetch_distribution_versions(
+        agent_id, distribution, repository, cache
+    )
+    if error:
+        return None, error
 
-    if "uvx" in distribution:
-        package_spec = distribution["uvx"].get("package", "")
-        package_name = extract_pypi_package_name(package_spec)
-        if not package_name:
-            return None, UpdateError(agent_id, "Could not extract PyPI package name")
-        versions = get_pypi_versions(package_name)
-        if not versions:
-            return None, UpdateError(agent_id, f"Could not fetch PyPI versions for {package_name}")
-        source_versions["uvx"] = (versions, f"https://pypi.org/pypi/{package_name}/json")
-
-    if "binary" in distribution and _is_github_repo(repository):
-        versions = get_github_release_versions(repository)
-        if not versions:
-            return None, UpdateError(
-                agent_id,
-                f"Could not fetch GitHub releases for {repository}",
-            )
-        source_versions["binary"] = (versions, repository)
-
-    if not source_versions:
+    if not published_versions:
         if distribution:
             return None, None  # Has distributions but none are checkable (e.g. binary without repo)
         return None, UpdateError(agent_id, "Unknown distribution type")
+
+    # Keep the stable channel on stable releases only
+    source_versions = {
+        dist_type: (get_stable_versions(versions), source_url)
+        for dist_type, (versions, source_url) in published_versions.items()
+    }
 
     common_versions: set[str] | None = None
     for versions, _source_url in source_versions.values():
@@ -399,7 +452,99 @@ def check_agent_version(
         distribution_type=dist_types,
         source_url=primary_source_url,
         repository=repository,
+        channel="stable",
     ), None
+
+
+def check_agent_preview_version(
+    agent_path: Path,
+    agent_data: dict,
+    cache: dict[str, set[str] | None] | None = None,
+) -> tuple[VersionUpdate | None, UpdateError | None]:
+    """Check if an agent has a newer version available on its preview channel.
+
+    The candidate is the highest of (highest published `X.Y.Z-preview.N`, highest
+    published stable release), so preview users always get the newest version that
+    exists - including a plain release once stable overtakes the preview line.
+    Only the distribution types declared inside `preview.distribution` take part;
+    there is no intersection with the base entry's other distributions and no
+    ordering constraint against the stable `version`.
+    """
+    preview = agent_data.get("preview")
+    if not isinstance(preview, dict):
+        return None, None
+
+    agent_id = agent_data.get("id", "unknown")
+    current_version = preview.get("version", "0.0.0")
+    distribution = preview.get("distribution", {})
+    repository = agent_data.get("repository", "")
+
+    published_versions, error = fetch_distribution_versions(
+        agent_id, distribution, repository, cache
+    )
+    if error:
+        return None, error._replace(error=f"preview: {error.error}")
+    if not published_versions:
+        return None, None
+
+    common_versions: set[str] | None = None
+    for versions, _source_url in published_versions.values():
+        common_versions = set(versions) if common_versions is None else common_versions & versions
+
+    candidates = [
+        candidate
+        for candidate in (
+            get_highest_preview_version(common_versions or set()),
+            get_highest_stable_version(common_versions or set()),
+        )
+        if candidate
+    ]
+    if not candidates:
+        return None, None  # Nothing published to point at; stay put
+
+    latest_version = max(candidates, key=semver_sort_key)
+    if latest_version == current_version:
+        return None, None  # Up to date
+
+    dist_types = "+".join(sorted(published_versions.keys()))
+    primary_source_url = next(iter(published_versions.values()))[1]
+
+    return VersionUpdate(
+        agent_id=agent_id,
+        agent_path=agent_path,
+        current_version=current_version,
+        latest_version=latest_version,
+        distribution_type=dist_types,
+        source_url=primary_source_url,
+        repository=repository,
+        channel="preview",
+    ), None
+
+
+def write_agent_data(agent_path: Path, agent_data: dict) -> bool:
+    """Write an agent manifest back to disk in the registry's canonical format."""
+    try:
+        with open(agent_path, "w") as f:
+            json.dump(agent_data, f, indent=2)
+            f.write("\n")
+        return True
+    except OSError as e:
+        print(f"Error writing {agent_path}: {e}", file=sys.stderr)
+        return False
+
+
+def update_package_specs(distribution: dict, new_version: str) -> None:
+    """Rewrite npx/uvx package specs in place so they pin `new_version`."""
+    if "npx" in distribution:
+        package_spec = distribution["npx"].get("package", "")
+        package_name = extract_npm_package_name(package_spec)
+        distribution["npx"]["package"] = f"{package_name}@{new_version}"
+
+    if "uvx" in distribution:
+        package_spec = distribution["uvx"].get("package", "")
+        distribution["uvx"]["package"] = re.sub(
+            rf"([=@]+){UVX_VERSION_PATTERN}", rf"\g<1>{new_version}", package_spec
+        )
 
 
 def apply_update(update: VersionUpdate) -> bool:
@@ -411,24 +556,26 @@ def apply_update(update: VersionUpdate) -> bool:
         print(f"Error reading {update.agent_path}: {e}", file=sys.stderr)
         return False
 
-    old_version = agent_data["version"]
     new_version = update.latest_version
+
+    if update.channel == "preview":
+        # Preview bumps touch the preview block only; the stable entry is untouched.
+        preview = agent_data.get("preview")
+        if not isinstance(preview, dict):
+            print(f"Error: {update.agent_path} has no 'preview' block", file=sys.stderr)
+            return False
+        preview["version"] = new_version
+        update_package_specs(preview.get("distribution", {}), new_version)
+        return write_agent_data(update.agent_path, agent_data)
+
+    old_version = agent_data["version"]
     distribution = agent_data.get("distribution", {})
 
     # Update version field
     agent_data["version"] = new_version
 
-    # Update npx package spec if present
-    if "npx" in distribution:
-        package_spec = distribution["npx"].get("package", "")
-        package_name = extract_npm_package_name(package_spec)
-        distribution["npx"]["package"] = f"{package_name}@{new_version}"
-
-    # Update uvx package spec if present
-    if "uvx" in distribution:
-        package_spec = distribution["uvx"].get("package", "")
-        new_package_spec = re.sub(r"([=@]+)[\d.]+", rf"\g<1>{new_version}", package_spec)
-        distribution["uvx"]["package"] = new_package_spec
+    # Update npx/uvx package specs if present
+    update_package_specs(distribution, new_version)
 
     # Update binary archive URLs if present
     if "binary" in distribution:
@@ -471,15 +618,8 @@ def apply_update(update: VersionUpdate) -> bool:
                             f"WARN: no release digest for {update.agent_id} ({platform_name})",
                             file=sys.stderr,
                         )
-    # Write back
-    try:
-        with open(update.agent_path, "w") as f:
-            json.dump(agent_data, f, indent=2)
-            f.write("\n")
-        return True
-    except OSError as e:
-        print(f"Error writing {update.agent_path}: {e}", file=sys.stderr)
-        return False
+
+    return write_agent_data(update.agent_path, agent_data)
 
 
 def main():
@@ -501,7 +641,18 @@ def main():
         action="store_true",
         help="Output results as JSON",
     )
+    parser.add_argument(
+        "--channels",
+        type=str,
+        default=",".join(CHANNELS),
+        help=f"Comma-separated release channels to check (default: {','.join(CHANNELS)})",
+    )
     args = parser.parse_args()
+
+    channels = [c.strip() for c in args.channels.split(",") if c.strip()]
+    unknown_channels = [c for c in channels if c not in CHANNELS]
+    if unknown_channels or not channels:
+        parser.error(f"--channels must be a subset of {','.join(CHANNELS)}")
 
     # Determine registry directory
     registry_dir = Path(__file__).parent.parent.parent
@@ -521,6 +672,11 @@ def main():
     errors: list[UpdateError] = []
     up_to_date: list[str] = []
 
+    checkers = {
+        "stable": check_agent_version,
+        "preview": check_agent_preview_version,
+    }
+
     # Check each agent
     for agent_path, agent_data in agents:
         agent_id = agent_data.get("id", "unknown")
@@ -528,20 +684,34 @@ def main():
         if not args.json:
             print(f"Checking {agent_id}...", end=" ", flush=True)
 
-        update, error = check_agent_version(agent_path, agent_data)
+        # One fetch per distribution source, shared by every channel
+        fetch_cache: dict[str, set[str] | None] = {}
+        agent_updates: list[VersionUpdate] = []
+        agent_errors: list[UpdateError] = []
 
-        if error:
-            errors.append(error)
-            if not args.json:
-                print(f"ERROR: {error.error}")
-        elif update:
-            updates.append(update)
-            if not args.json:
-                print(f"UPDATE: {update.current_version} -> {update.latest_version}")
-        else:
+        for channel in CHANNELS:
+            if channel not in channels:
+                continue
+            update, error = checkers[channel](agent_path, agent_data, fetch_cache)
+            if error:
+                agent_errors.append(error)
+            elif update:
+                agent_updates.append(update)
+
+        updates.extend(agent_updates)
+        errors.extend(agent_errors)
+        if not agent_updates and not agent_errors:
             up_to_date.append(agent_id)
-            if not args.json:
-                print(f"OK ({agent_data.get('version', 'unknown')})")
+
+        if not args.json:
+            messages = [f"ERROR: {e.error}" for e in agent_errors]
+            messages += [
+                f"UPDATE [{u.channel}]: {u.current_version} -> {u.latest_version}"
+                for u in agent_updates
+            ]
+            if not messages:
+                messages.append(f"OK ({agent_data.get('version', 'unknown')})")
+            print("; ".join(messages))
 
     # Output results
     if args.json:
@@ -550,6 +720,7 @@ def main():
                 {
                     "agent_id": u.agent_id,
                     "agent_path": str(u.agent_path),
+                    "channel": u.channel,
                     "current_version": u.current_version,
                     "latest_version": u.latest_version,
                     "distribution_type": u.distribution_type,
@@ -573,7 +744,7 @@ def main():
             print("Updates available:")
             for u in updates:
                 print(
-                    f"  - {u.agent_id}: {u.current_version} -> "
+                    f"  - {u.agent_id} ({u.channel}): {u.current_version} -> "
                     f"{u.latest_version} ({u.distribution_type})"
                 )
 

--- a/.github/workflows/uv.lock
+++ b/.github/workflows/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "acp-registry-scripts"
+version = "1.0.0"
+source = { virtual = "." }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ This is a registry of ACP (Agent Client Protocol) agents. The structure is:
 1. Scans directories for `agent.json` files
 2. Validates against `agent.schema.json` (JSON Schema)
 3. Validates icons (16x16 SVG, monochrome with `currentColor`)
-4. Aggregates into `dist/registry.json`
+4. Aggregates into three views: `dist/registry.json`, `dist/registry-for-jetbrains.json` and `dist/registry-for-jetbrains-preview.json`
 5. Copies icons to `dist/<id>.svg`
 
 **CI/CD** (`.github/workflows/build-registry.yml`):
@@ -95,9 +95,34 @@ This is a registry of ACP (Agent Client Protocol) agents. The structure is:
 - `binary` archives must use supported formats (`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, or raw binaries); installer formats (`.dmg`, `.pkg`, `.deb`, `.rpm`, `.msi`, `.appimage`) are rejected
 - `binary` archives should pin the archive SHA-256 checksum with `sha256` field
 - `icon.svg`: must be SVG format, 16x16, monochrome using `currentColor` (enables theming)
-- **URL validation**: All distribution URLs must be accessible (binary archives, npm/PyPI packages)
+- `preview` (optional): exactly `version` + `distribution`; `version` matches `X.Y.Z-preview.N` or a plain `X.Y.Z`; `distribution` is `npx`/`uvx` only. Checked offline only — see [Preview Channel](#preview-channel)
+- **URL validation**: All distribution URLs must be accessible (binary archives, npm/PyPI packages). Preview distributions are exempt
 
 Set `SKIP_URL_VALIDATION=1` to bypass URL checks during local development.
+
+## Preview Channel
+
+An agent may declare an optional `preview` block in its `agent.json`, holding **exactly two** fields — `version` and `distribution`:
+
+```json
+  "preview": {
+    "version": "1.9.0-preview.1",
+    "distribution": {
+      "npx": { "package": "@agentclientprotocol/codex-acp@1.9.0-preview.1" }
+    }
+  }
+```
+
+See [FORMAT.md](FORMAT.md#preview-channel) for the full contract. Key points when working in this repo:
+
+- **Three build outputs.** `registry.json` and `registry-for-jetbrains.json` always carry the **stable** `version`/`distribution` with the `preview` key stripped. `registry-for-jetbrains-preview.json` is a complete, drop-in replacement for the JetBrains registry where a previewed agent appears as an ordinary entry with `version` and `distribution` substituted by the preview values (and still no `preview` key). Agents without a `preview` block appear there at their stable version.
+- **Version scheme `X.Y.Z-preview.N`.** Valid semver; `1.9.0-preview.N` ranks below `1.9.0`, and `preview.10` ranks above `preview.2`. The root `version` must stay a plain `X.Y.Z` release.
+- **Highest of both channels wins.** `preview.version` means "the newest version we know about", so it may legitimately hold a plain release. A `preview.version` at or below the stable `version` is **not** an error — the build simply serves the stable entry, and the hourly checker rewrites the block on the next run. Never add an ordering constraint between the channels.
+- **Preview is deliberately unverified.** Preview distributions are never launched (`verify_agents.py` and `protocol_matrix.py` stay stable-only), their URLs are never probed, and they add no CI jobs. The only preview-specific check is offline: the package spec's pinned version must equal `preview.version`.
+- **`binary` preview distributions are not supported** — the schema restricts `preview.distribution` to `npx`/`uvx`.
+- **Wrapper-repo prerequisite:** preview artifacts must be published as `npm publish --tag preview`. Publishing a prerelease without `--tag preview` moves `dist-tags.latest` onto it, which the stable checker's fallback path guards against but should not be relied on.
+
+Shared helpers live in `.github/workflows/registry_utils.py`: `semver_sort_key`, `resolve_preview_entry` (the single definition of "what a preview entry is") and `strip_preview`.
 
 ## Updating Agent Versions
 
@@ -110,7 +135,7 @@ Agent versions are automatically updated via `.github/workflows/update-versions.
 - **Supported distributions:** `npx` (npm), `uvx` (PyPI), `binary` (GitHub releases only — non-GitHub `repository` URLs are skipped)
 
 ```bash
-# Dry run - check for available updates
+# Dry run - check for available updates (both channels)
 uv run .github/workflows/update_versions.py
 
 # Apply updates locally
@@ -118,7 +143,12 @@ uv run .github/workflows/update_versions.py --apply
 
 # Check specific agents only
 uv run .github/workflows/update_versions.py --agents gemini,github-copilot
+
+# Check a single release channel
+uv run .github/workflows/update_versions.py --channels preview
 ```
+
+Both channels are checked from a single fetch per distribution source. Stable updates rewrite the root `version` and distribution specs; preview updates rewrite only `preview.version` and the preview specs. Each entry in the `--json` payload carries a `channel` field, and only `stable` bumps are auth-verified.
 
 The workflow can also be triggered manually via GitHub Actions with options to apply updates and filter by agent IDs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ python .github/workflows/build_registry.py
 .github/workflows/scripts/run-workflows-tests.sh
 
 # Run workflow tests natively on the host (CI-style debugging only)
-cd .github/workflows && uv run --with pytest pytest tests/ -v
+cd .github/workflows && uv run --with pytest --with jsonschema pytest tests/ -v
 
 # Lint check
 cd .github/workflows && uv run --with ruff ruff check .

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -47,6 +47,76 @@ Each agent has the following structure:
 
 The `license_url` field is required and must link to the agent's license text or terms of service. DimCode (`id: dimcode`) is exempt from this requirement.
 
+## Preview Channel
+
+An agent may declare an optional `preview` block holding **exactly two** fields — `version` and `distribution`. It describes the same agent on an unstable release channel; all other metadata (`name`, `description`, `repository`, `authors`, `license`, icon) is shared with the stable entry and must never be duplicated.
+
+```json
+{
+  "id": "codex-acp",
+  "version": "1.8.0",
+  "distribution": {
+    "npx": { "package": "@agentclientprotocol/codex-acp@1.8.0" }
+  },
+  "preview": {
+    "version": "1.9.0-preview.1",
+    "distribution": {
+      "npx": { "package": "@agentclientprotocol/codex-acp@1.9.0-preview.1" }
+    }
+  }
+}
+```
+
+`preview.distribution` is a full distribution object validated against the same schema definitions as the root `distribution`, restricted to `npx` and `uvx`. **`binary` preview distributions are not supported.**
+
+### Version scheme
+
+Preview versions use `X.Y.Z-preview.N`, where `X.Y.Z` is the next, not-yet-released stable version and `N` is a 1-based counter:
+
+```
+1.9.0-preview.1  →  1.9.0-preview.2  →  …  →  1.9.0-preview.10  →  1.9.0 (stable)
+```
+
+This is valid semver, so precedence works out as expected: `1.9.0-preview.N` ranks below the `1.9.0` release it targets, and `preview.10` ranks above `preview.2` because a purely numeric prerelease identifier is compared numerically. Shapes like `1.0-preview-1`, `1.9.0-rc.1` or `1.9.0+preview.1` are rejected.
+
+The root `version` field is always a plain `X.Y.Z` release — a prerelease there is a validation error.
+
+### Highest of both channels wins
+
+`preview.version` means *"the newest version we know about"*, not *"a prerelease"*, so it may legitimately hold a plain `X.Y.Z` release. When the stable channel overtakes the preview line (stable ships `1.9.1` while the newest preview is still `1.9.0-preview.1`), that is **not** an error:
+
+| Manifest state                                          | Preview registry serves           |
+| ------------------------------------------------------- | --------------------------------- |
+| `version: 1.8.0`, `preview.version: 1.9.0-preview.2`    | `1.9.0-preview.2`                 |
+| `version: 1.9.1`, `preview.version: 1.9.0-preview.1`    | `1.9.1` (stable is newer)         |
+| `version: 1.9.1`, `preview.version: 1.9.1`              | `1.9.1` (identical to stable)     |
+| no `preview` block                                      | the stable entry                  |
+
+A stale preview block therefore self-heals on the next hourly run instead of failing the build.
+
+### Published preview entries
+
+The `preview` key never appears in any published registry. It is stripped from `registry.json` and `registry-for-jetbrains.json`, and in `registry-for-jetbrains-preview.json` the previewed agent appears as an **ordinary agent entry** with `version` and `distribution` substituted wholesale by the preview values:
+
+```json
+{
+  "id": "codex-acp",
+  "name": "Codex",
+  "version": "1.9.0-preview.1",
+  "description": "ACP adapter for OpenAI's coding assistant",
+  "repository": "https://github.com/agentclientprotocol/codex-acp",
+  "distribution": {
+    "npx": { "package": "@agentclientprotocol/codex-acp@1.9.0-preview.1" }
+  }
+}
+```
+
+`registry-for-jetbrains-preview.json` is a complete, drop-in replacement for `registry-for-jetbrains.json`: agents without a `preview` block appear at their stable version, so a client points at one URL and never merges two files.
+
+### The preview channel is unverified
+
+Preview is an explicitly unstable, best-effort channel. Preview distributions are **never** launched or auth-checked, their URLs are **not** probed for reachability, and they do **not** appear in the nightly protocol matrix. The only checks applied are offline ones: schema validation, and the requirement that the package spec's pinned version equals `preview.version`.
+
 ## Distribution Types
 
 | Type     | Description                   | Command                |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Fetch the registry index:
 https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json
 ```
 
+JetBrains IDEs use a dedicated index, plus an opt-in preview channel that serves the newest available version (preview build or stable release) for agents that publish one:
+
+```
+https://cdn.agentclientprotocol.com/registry/v1/latest/registry-for-jetbrains.json
+https://cdn.agentclientprotocol.com/registry/v1/latest/registry-for-jetbrains-preview.json
+```
+
+The preview index is a complete, drop-in replacement for the JetBrains index — agents without a preview channel appear at their stable version. Preview distributions are **not** verified; see [FORMAT.md](FORMAT.md#preview-channel).
+
 ## Registry Format
 
 See [FORMAT.md](FORMAT.md) for the registry schema, distribution types, and platform targets.

--- a/agent.schema.json
+++ b/agent.schema.json
@@ -27,8 +27,8 @@
     },
     "version": {
       "type": "string",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+",
-      "description": "Semantic version"
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Semantic version of the stable release channel"
     },
     "description": {
       "type": "string",
@@ -80,9 +80,39 @@
         }
       },
       "additionalProperties": false
+    },
+    "preview": {
+      "$ref": "#/definitions/previewChannel"
     }
   },
   "definitions": {
+    "previewChannel": {
+      "type": "object",
+      "description": "Optional preview (unstable) release channel. Holds only the version and the artifact locations; all other metadata is shared with the stable entry.",
+      "required": ["version", "distribution"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-preview\\.[0-9]+)?$",
+          "description": "Newest known version for the preview channel: X.Y.Z-preview.N, or a plain X.Y.Z release when the stable channel is ahead of the preview line"
+        },
+        "distribution": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "Preview artifact locations. Only package-based distributions are supported.",
+          "properties": {
+            "npx": {
+              "$ref": "#/definitions/packageDistribution"
+            },
+            "uvx": {
+              "$ref": "#/definitions/packageDistribution"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "binaryDistribution": {
       "type": "object",
       "minProperties": 1,

--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -15,5 +15,13 @@
     "npx": {
       "package": "@agentclientprotocol/claude-agent-acp@0.75.1"
     }
+  },
+  "preview": {
+    "version": "0.73.0",
+    "distribution": {
+      "npx": {
+        "package": "@agentclientprotocol/claude-agent-acp@0.73.0"
+      }
+    }
   }
 }

--- a/claude-acp/agent.json
+++ b/claude-acp/agent.json
@@ -17,10 +17,10 @@
     }
   },
   "preview": {
-    "version": "0.73.0",
+    "version": "0.75.2-preview.1",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/claude-agent-acp@0.73.0"
+        "package": "@agentclientprotocol/claude-agent-acp@0.75.2-preview.1"
       }
     }
   }

--- a/codex-acp/agent.json
+++ b/codex-acp/agent.json
@@ -15,5 +15,13 @@
     "npx": {
       "package": "@agentclientprotocol/codex-acp@1.10.0"
     }
+  },
+  "preview": {
+    "version": "1.8.0",
+    "distribution": {
+      "npx": {
+        "package": "@agentclientprotocol/codex-acp@1.8.0"
+      }
+    }
   }
 }

--- a/codex-acp/agent.json
+++ b/codex-acp/agent.json
@@ -17,10 +17,10 @@
     }
   },
   "preview": {
-    "version": "1.8.0",
+    "version": "1.10.1-preview.1",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/codex-acp@1.8.0"
+        "package": "@agentclientprotocol/codex-acp@1.10.1-preview.1"
       }
     }
   }


### PR DESCRIPTION
## What & why

Adds an opt-in **preview channel** so JetBrains IDEs can ship newer, unstable ACP wrapper builds (starting with `codex-acp` and `claude-acp`) without affecting the public registries.

An agent may now declare an optional `preview` block in its `agent.json` holding **exactly** `version` + `distribution`. The build emits a third, self-contained index `dist/registry-for-jetbrains-preview.json` in which a previewed agent appears as an *ordinary* entry — same `id` and metadata, with `version`/`distribution` substituted from the `preview` block and the `preview` key stripped. Agents without a `preview` block appear there at their stable version, so the file is a drop-in replacement for `registry-for-jetbrains.json`.

```json
"preview": {
  "version": "1.9.0-preview.1",
  "distribution": {
    "npx": { "package": "@agentclientprotocol/codex-acp@1.9.0-preview.1" }
  }
}
```

## Key design decisions

- **Version scheme `X.Y.Z-preview.N`** — valid semver; `1.9.0-preview.N` ranks below `1.9.0`, and `preview.10` correctly outranks `preview.2` (numeric prerelease identifiers).
- **Highest of both channels wins.** `preview.version` means "the newest version we know about", so it may legitimately hold a plain `X.Y.Z` release. A stale preview is **not** an error: the hourly checker writes `max(highest published preview, highest published stable)`, and the build falls back to the stable entry when stable is ahead. No build failure, no downgrade for preview users.
- **Preview is deliberately unverified.** Preview distributions are never launched (`verify_agents.py` and `protocol_matrix.py` stay stable-only), their URLs are never probed, and no new CI jobs are added. The only preview-specific check is offline: the package spec's pinned version must equal `preview.version`. Speed and simplicity over safety on an explicitly unstable channel.
- **`npx`/`uvx` only** — `binary` preview distributions are rejected by the schema.

## Changes

**Schema & manifests**
- `agent.schema.json`: anchored the root `version` pattern (a prerelease can no longer leak into the stable field); added the `previewChannel` definition (`required: version + distribution`, `additionalProperties: false`, `npx`/`uvx` reusing `packageDistribution`).
- Seeded `preview` blocks for `codex-acp` and `claude-acp`.

**Build**
- `registry_utils.py`: `PREVIEW_VERSION_RE`, `parse_preview_version`, `is_preview_version`, `semver_sort_key`, `version_tuple`/`normalize_release_version` (hoisted from the checker), `strip_preview`, and `resolve_preview_entry` — the single definition of "what a preview entry is", shared by all scripts.
- `build_registry.py`: offline `validate_preview`; both public registries mapped through `strip_preview`; third output written, with a build summary listing which ids are actually ahead of stable; optional `registry_dir` argument for testability.
- `build-registry.yml`: new file added to the release assets (S3 `aws s3 sync dist/` needs no change).

**Hourly version updates**
- `update_versions.py`: `VersionUpdate.channel`; `fetch_distribution_versions` with a per-agent source cache so both channels share one fetch per source; `get_highest_preview_version`; `check_agent_preview_version`; channel-branching `apply_update`; `channel` in the `--json` payload and a new `--channels` filter. The `dist-tags.latest` fallback remains stable-only.
- `update-versions.yml`: staging map re-keyed `path → {channel → version}` (a path-only key let one channel mask the other) and asserted against the right field per channel; auth verification filtered to stable ids and skipped when empty; channel rendered in commit messages.

**Docs & tooling**
- Documented the channel in `FORMAT.md`, `AGENTS.md`, `README.md`, including the new CDN path and the wrapper-repo prerequisite (`npm publish --tag preview` — publishing a prerelease without it moves `dist-tags.latest` onto it).
- Added `--with jsonschema` to both test runners: schema validation was silently skipped in every test run before this.
