### PR TITLE
Add neoncodex-acp-agent

### DIFF
--- a/neoncodex-acp-agent/agent.json
+++ b/neoncodex-acp-agent/agent.json
@@ -1,0 +1,15 @@
+{
+  "id": "neoncodex-acp-agent",
+  "name": "NeonCodex",
+  "version": "1.0.2",
+  "description": "ACP agent for NeonCodex AI, enabling JetBrains IDE integration",
+  "repository": "https://github.com/BrowserlessAPI/neoncodex-acp-agent",
+  "website": "https://neoncodex.io",
+  "authors": ["Viper"],
+  "license": "ISC",
+  "distribution": {
+    "npx": {
+      "package": "neoncodex-acp-agent@1.0.2"
+    }
+  }
+}

--- a/neoncodex-acp-agent/icon.svg
+++ b/neoncodex-acp-agent/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 1l6 3.5v7L8 15l-6-3.5v-7L8 1z"/>
+</svg>


### PR DESCRIPTION
Adds NeonCodex AI as an ACP agent, distributed via npm (npx).

- Package: neoncodex-acp-agent@1.0.2
- Repository: https://github.com/BrowserlessAPI/neoncodex-acp-agent
- Supports agent-handled authentication via NEONCODEX_API_KEY
- Verified locally with SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py — builds cleanly alongside all existing entries.