### PR TITLE
Add deel

### DIFF
--- a/deel/agent.json
+++ b/deel/agent.json
@@ -1,0 +1,22 @@
+{
+  "id": "deel",
+  "name": "deel",
+  "version": "1.15.1",
+  "description": "A coding agent for local models and private gateways. Zero dependencies, no telemetry.",
+  "repository": "https://github.com/jysvai/deel-local-cli",
+  "website": "https://github.com/jysvai/deel-local-cli",
+  "authors": [
+    "yunseok"
+  ],
+  "license": "MIT",
+  "license_url": "https://github.com/jysvai/deel-local-cli/blob/main/LICENSE",
+  "icon": "./icon.svg",
+  "distribution": {
+    "npx": {
+      "package": "deel-local-cli@1.15.1",
+      "args": [
+        "acp"
+      ]
+    }
+  }
+}

--- a/deel/icon.svg
+++ b/deel/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="M8 1.5 15 7.2h-2.1v7H9.6V10H6.4v4.2H3.1v-7H1L8 1.5Z"/></svg>


### PR DESCRIPTION
Adds `deel` — a coding agent CLI built for **local models and private gateways**.

- **Repo**: https://github.com/jysvai/deel-local-cli
- **npm**: `deel-local-cli@1.15.1`
- **License**: MIT
- **Distribution**: `npx deel-local-cli@1.15.1 acp`

### What it is

deel targets the case where the model is on your own machine or behind a
corporate gateway, not in a vendor datacenter. Zero runtime dependencies, no
install scripts, no telemetry. It detects local runtimes (Ollama, LM Studio,
llama.cpp) and speaks OpenAI-compatible and Anthropic wire formats.

### Authentication

Terminal Auth. `initialize` returns:

```json
{
  "id": "terminal-setup",
  "name": "Run `deel setup` in a terminal",
  "description": "Pick a local runtime (Ollama / LM Studio / llama.cpp) or enter a gateway URL and key.",
  "type": "terminal",
  "args": ["setup"]
}
```

`session/new` returns `-32000` (auth required) when no connection is configured,
and `authenticate` verifies setup actually completed before reporting success.

I ran the registry's own auth check locally against the exact command from
`agent.json`:

```
$ npx -y deel-local-cli@1.15.1 acp
PASS  Auth OK: terminal-setup(terminal)
version from npm package: 1.15.1
```

### Checklist

- [x] `agent.json` validates against `agent.schema.json`
- [x] `icon.svg` is 16x16, square, monochrome `currentColor`, no hardcoded colors
- [x] Directory name matches `id`
- [x] npm package published, version pinned (no `@latest`)
- [x] Returns `authMethods` with `type: "terminal"`