### PR TITLE
Add Kimchi to the ACP Registry

### DIFF
--- a/kimchi/agent.json
+++ b/kimchi/agent.json
@@ -1,0 +1,44 @@
+{
+  "id": "kimchi",
+  "name": "Kimchi",
+  "version": "1.1.11",
+  "description": "Coding agent powered by multi-model orchestration",
+  "repository": "https://github.com/getkimchi/kimchi",
+  "website": "https://kimchi.dev",
+  "authors": ["Kimchi"],
+  "license": "Apache-2.0",
+  "distribution": {
+    "binary": {
+      "darwin-aarch64": {
+        "archive": "https://github.com/getkimchi/kimchi/releases/download/v1.1.11/kimchi_darwin_arm64.tar.gz",
+        "sha256": "9614064e7ff5d96163b9faca4306f2fb05a82a0185bb791f60928adc73b168b0",
+        "cmd": "./bin/kimchi",
+        "args": ["--mode", "acp"]
+      },
+      "darwin-x86_64": {
+        "archive": "https://github.com/getkimchi/kimchi/releases/download/v1.1.11/kimchi_darwin_amd64.tar.gz",
+        "sha256": "788e505afbdfee0d05fce68b5c978cd7cd93386fa0d473c47b50480603a4207c",
+        "cmd": "./bin/kimchi",
+        "args": ["--mode", "acp"]
+      },
+      "linux-aarch64": {
+        "archive": "https://github.com/getkimchi/kimchi/releases/download/v1.1.11/kimchi_linux_arm64.tar.gz",
+        "sha256": "625f41ac3dda2fc9f4efaedf75877c567283f0db2815aeb36eea1df6bd77fdf4",
+        "cmd": "./bin/kimchi",
+        "args": ["--mode", "acp"]
+      },
+      "linux-x86_64": {
+        "archive": "https://github.com/getkimchi/kimchi/releases/download/v1.1.11/kimchi_linux_amd64.tar.gz",
+        "sha256": "4c571aa2653c3409e9d27c66ec230eb3e6b9684d3ea01d3313e9d082031faa93",
+        "cmd": "./bin/kimchi",
+        "args": ["--mode", "acp"]
+      },
+      "windows-x86_64": {
+        "archive": "https://github.com/getkimchi/kimchi/releases/download/v1.1.11/kimchi_windows_amd64.zip",
+        "sha256": "c0432cc4cf9aa9494674a1bba6f92398654a31b8ac38e85d0ef56086750986f5",
+        "cmd": "./bin/kimchi.exe",
+        "args": ["--mode", "acp"]
+      }
+    }
+  }
+}

--- a/kimchi/icon.svg
+++ b/kimchi/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M3 1h2.5v5.5L9 1h3L8.5 6.5 12.5 13H9.5L6 8v5H3V1z"/>
+</svg>


### PR DESCRIPTION
Adds [Kimchi](https://github.com/getkimchi/kimchi) to the ACP registry.

 - Distribution: Binary (darwin-arm64, darwin-x86_64, linux-arm64, linux-x86_64, windows-x86_64) from GitHub release v1.1.11
 - ACP mode: ./bin/kimchi --mode acp
 - Auth: Supports Agent Auth (browser-based OAuth) and Terminal Auth (kimchi login)
 - Icon: 16x16 monochrome SVG using currentColor