### PR TITLE
Add MiniMax Code 0.2.7

### DIFF
--- a/minimax-code/agent.json
+++ b/minimax-code/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "minimax-code",
+  "name": "MiniMax Code",
+  "version": "0.2.7",
+  "description": "MiniMax Code is an AI coding agent with Agent Client Protocol support.",
+  "website": "https://agent.minimax.io",
+  "authors": [
+    "MiniMax"
+  ],
+  "license": "MIT",
+  "license_url": "https://agent.minimax.io/doc/en/terms-of-service.html",
+  "distribution": {
+    "npx": {
+      "package": "@minimax-ai/code@0.2.7",
+      "args": [
+        "acp"
+      ]
+    }
+  }
+}

--- a/minimax-code/icon.svg
+++ b/minimax-code/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M2 3h3l3 5 3-5h3v10h-2V6.5l-4 6-4-6V13H2V3Z"/>
+</svg>


### PR DESCRIPTION
Add MiniMax Code 0.2.7 to the registry so ACP clients can discover and launch it. Replaces #515, retaining its ID and icon with author credit in the commit.

Scope: two new files under `minimax-code/`. No changes to other agents, launchers, or workflows.

**Version limitation:** npm latest 0.3.10 exposes two different binaries and fails with `could not determine executable to run` under npx. This entry uses the verified 0.2.7 release; automatic upgrades require a package publishing fix.

Validation on macOS arm64 / Node 22.23.2:

- Schema and icon validation: 42 agents passed with `SKIP_URL_VALIDATION=1`.
- Actual npm installation and ACP auth check passed: `minimax-code-login(terminal)`.
- Authenticated `session/new` and `session/prompt` returned `ACP_SMOKE_OK` and `end_turn`.
- Package and license URLs returned HTTP 200; `git diff --check` passed. Full URL validation is blocked by this host's proxy DNS, including for existing entries.


<details>
<summary>Local run output (2026-09-09)</summary>

Auth verification output, with local paths anonymized:

```text
[1/1] minimax-code (npx)
  Testing npx...
    → Auth check: npx --prefix /tmp/mcode-registry-test/work/acp-registry/.sandbox/npx/minimax-code...
    ✓ Success: Auth OK: minimax-code-login(terminal)
    Sandbox: /tmp/mcode-registry-test/work/acp-registry/.sandbox/npx/minimax-code

==================================================
Summary
==================================================
  Passed:  1
  Failed:  0
  Skipped: 0

All tests passed!
```

Selected messages from the authenticated ACP session:

```json
[
  {
    "agentInfo": {
      "name": "minimax-code",
      "title": "MiniMax Code",
      "version": "0.2.7"
    }
  },
  {
    "sessionUpdate": "agent_message_chunk",
    "messageId": "caa0538c-a12a-42b1-b840-dbdb0f2adef4",
    "content": {
      "type": "text",
      "text": "ACP_SMOKE_OK"
    }
  },
  {
    "jsonrpc": "2.0",
    "id": 3,
    "result": {
      "stopReason": "end_turn"
    }
  }
]
```

</details>
