### PR TITLE
Add agent-bridge

### DIFF
--- a/agent-bridge/agent.json
+++ b/agent-bridge/agent.json
@@ -1,0 +1,19 @@
+{
+  "id": "agent-bridge",
+  "name": "agent-bridge",
+  "version": "0.3.0",
+  "description": "One bridge for many CLI coding agents: spawn codex (native adapter), Claude Code, pi, or any ACP agent by name as a single stdio ACP agent — with approval-flow mapping (once/always/deny by kind), session resume across bridge restarts, and image passthrough. Zero npm dependencies.",
+  "repository": "https://github.com/xiaohuzai/agent-bridge",
+  "website": "https://github.com/xiaohuzai/agent-bridge#readme",
+  "authors": [
+    "xiaohuzai"
+  ],
+  "license": "MIT",
+  "license_url": "https://github.com/xiaohuzai/agent-bridge/blob/main/LICENSE",
+  "distribution": {
+    "npx": {
+      "package": "@xiaohuzai/agent-bridge@0.3.0",
+      "args": ["acp", "claude"]
+    }
+  }
+}

--- a/agent-bridge/icon.svg
+++ b/agent-bridge/icon.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1.5 6.5C4.5 3.4 11.5 3.4 14.5 6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M4 5.9V11.5M12 5.9V11.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M1.5 11.5H14.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## agent-bridge

One bridge for many CLI coding agents — spawns one config entry as a stdio ACP v1 agent for editors and other spawn-style clients:

```bash
npx @xiaohuzai/agent-bridge@0.3.0 acp claude
```

Zero config needed: with no `--config`, the registry's built-in default command for the name is spawned (`acp codex` and `acp pi` work the same way; editors can override args, e.g. `acp codex --config /abs/agents.json`).

**What it is**

- Speaks ACP v1 on stdio (`initialize` → `session/new` → `session/prompt`; the prompt RPC response is the turn terminator), accepting clients that propose newer protocol versions by answering with the version it speaks.
- Behind the ACP door it drives the real agents: codex via a native app-server adapter (no shim), Claude Code and pi via their official/community ACP shims, and any ACP agent by adding one registry line.
- Approval-flow mapping done by `kind` (`allow_once`/`allow_always`/`reject_once`/`reject_always` → the agent's own `optionId`), sessions resume across bridge restarts (session/resume with session/load fallback), images ride through as data URLs gated on the advertised `promptCapabilities.image`. Zero npm dependencies, Node ≥ 18.

**Verification**: every adapter fact was captured live against the real CLIs/shims (codex app-server, official `@agentclientprotocol/codex-acp` and `claude-agent-acp`, pi-acp); the test suite drives the real adapter and real server against scripted fake agents (77 tests, runs in CI).

- Repository: https://github.com/xiaohuzai/agent-bridge
- Per-agent setup docs: https://github.com/xiaohuzai/agent-bridge/blob/main/docs/agents.md
- License: MIT (license_url links to it)

The entry pins `@xiaohuzai/agent-bridge@0.3.0` (current npm latest); version bumps will track releases.